### PR TITLE
Run full test suite on rspec

### DIFF
--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 Capybara::SpecHelper.run_specs TestSessions::Cuprite, "Cuprite"
 
-describe Capybara::Session do
+describe Capybara::Cuprite do
   context "with cuprite driver" do
     before { @session = TestSessions::Cuprite }
     after { @session.reset! }


### PR DESCRIPTION
Without this change only the specs imported from Capybara
get run on bundle exec rspec. I am not exactly sure why that happens.