### PR TITLE
Fix color inputs

### DIFF
--- a/lib/capybara/cuprite/node.rb
+++ b/lib/capybara/cuprite/node.rb
@@ -104,6 +104,8 @@ module Capybara::Cuprite
         when "file"
           files = value.respond_to?(:to_ary) ? value.to_ary.map(&:to_s) : value.to_s
           command(:select_file, files)
+        when "color"
+          node.evaluate("this.setAttribute('value', '#{value}')")
         else
           command(:set, value.to_s)
         end

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -241,6 +241,12 @@ describe Capybara::Session do
           FileUtils.rm_f(filename)
         end
       end
+
+      it "sets a value for a color input" do
+        element = @session.find(:css, "#change_me_color")
+        element.set("#ddeeff")
+        expect(element.value).to eq("#ddeeff")
+      end
     end
 
     describe "Node#visible" do

--- a/spec/support/views/with_js.erb
+++ b/spec/support/views/with_js.erb
@@ -38,6 +38,7 @@
       <input type="text" name="change_me_withname" id="change_me_withname">
     </p>
     <p><input type="file" name="change_me_file" id="change_me_file"></p>
+    <p><input type="color" name="change_me_color" id="change_me_color"></p>
     <p id="changes"></p>
     <p id="changes_on_input"></p>
     <p id="changes_on_keydown"></p>


### PR DESCRIPTION
At present it's not possible to assign a value to color inputs. No matter what value you try to set, the input's value is always set to `#000000`. This PR adds a failing spec and solution.

I resorted to using `node.evaluate`, which I did not see anywhere else in the codebase. If there is a better way to solve this problem, or one that is more consistent with how you'd like the library to work then please let me know and I'll be happy to modify my PR.

At @EpionHealth we are switching a medium-sized spec suite from Capybara Webkit to Chrome and Cuprite and it's mostly worked well for us. If we encounter any other issues with Cuprite we'll attempt to fix them and follow up with you. Many thanks for your useful and well-written library.