### PR TITLE
Fix visibility for out-of-viewport elements

### DIFF
--- a/lib/capybara/cuprite/javascripts/index.js
+++ b/lib/capybara/cuprite/javascripts/index.js
@@ -75,7 +75,8 @@ class Cuprite {
 
     while (node) {
       style = window.getComputedStyle(node);
-      if (style.display === "none" || style.visibility === "hidden" || parseFloat(style.opacity) === 0) {
+
+      if (style.display === "none" || style.visibility === "hidden" || parseFloat(style.opacity) === 0 || !this._isInViewport(node)) {
         return false;
       }
       node = node.parentElement;

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -266,7 +266,7 @@ describe Capybara::Session do
         expect(@session.find(:css, "li", text: "Transparent", visible: false).visible?).to be false
       end
 
-      it "element with all children hidden returns empty text" do
+      it "returns empty text for elements with all children hidden" do
         expect(@session.find(:css, "div").text).to eq("")
       end
     end

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -269,6 +269,10 @@ describe Capybara::Session do
       it "returns empty text for elements with all children hidden" do
         expect(@session.find(:css, "div").text).to eq("")
       end
+
+      it "considers out-of-viewport elements to not be visible" do
+        expect(@session.find(:css, "li", text: "Out of viewport", visible: false).visible?).to be false
+      end
     end
 
     describe "Node#checked?" do

--- a/spec/support/views/visible.erb
+++ b/spec/support/views/visible.erb
@@ -10,6 +10,7 @@
       <li style="display: none">Display None</li>
       <li style="visibility: hidden">Hidden</li>
       <li style="opacity: 0.0">Transparent</li>
+      <li style="list-style-type:none; position: absolute; left: 100vw;">Out of viewport</li>
     </ul>
     <div>
       <span style="display: none">Display None</span>


### PR DESCRIPTION
At present elements outside of the viewport are considered visible by Cuprite, which does not match the behavior of Chrome Webdriver. This caused some specs in my app which passed with Chrome Webdriver to fail with Cuprite.

This PR adds a failing spec and a solution, and also tweaks the language of an unrelated spec example to match the others around it.