### PR TITLE
Fix request interception when using a black/whitelist

### DIFF
--- a/lib/capybara/cuprite/page.rb
+++ b/lib/capybara/cuprite/page.rb
@@ -135,23 +135,14 @@ module Capybara::Cuprite
                            !Array(@browser.url_blacklist).empty?
 
       on(:request) do |request, index, total|
-        if @browser.url_blacklist && !@browser.url_blacklist.empty?
-          if @browser.url_blacklist.any? { |r| request.match?(r) }
-            request.abort and next
-          else
-            request.continue and next
-          end
-        elsif @browser.url_whitelist && !@browser.url_whitelist.empty?
-          if @browser.url_whitelist.any? { |r| request.match?(r) }
-            request.continue and next
-          else
-            request.abort and next
-          end
-        elsif index + 1 < total
-          # There are other callbacks that may handle this request
-          next
-        else
-          # If there are no callbacks then just continue
+        if @browser.url_blacklist && @browser.url_blacklist.any? { |r| request.match?(r) }
+          request.abort and next
+        elsif @browser.url_whitelist && !@browser.url_whitelist.empty? && @browser.url_whitelist.none? { |r| request.match?(r) }
+          request.abort and next
+        end
+
+        if index + 1 >= total
+          # Continue the request if there are no other callbacks
           request.continue
         end
       end

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -783,7 +783,7 @@ module Capybara::Cuprite
           %r{/cuprite/jquery.min.js$}    => File.size(CUPRITE_ROOT + "/spec/support/public/jquery-1.11.3.min.js"),
           %r{/cuprite/jquery-ui.min.js$} => File.size(CUPRITE_ROOT + "/spec/support/public/jquery-ui-1.11.4.min.js"),
           %r{/cuprite/test.js$}          => File.size(CUPRITE_ROOT + "/spec/support/public/test.js"),
-          %r{/cuprite/with_js$}          => 2329
+          %r{/cuprite/with_js$}          => 2405
         }
 
         resources_size.each do |resource, size|


### PR DESCRIPTION
This PR aims to resolve two issues:
1. Intercepted requests [would](https://github.com/rubycdp/cuprite/blob/master/lib/capybara/cuprite/page.rb#L142) [always](https://github.com/rubycdp/cuprite/blob/master/lib/capybara/cuprite/page.rb#L146) be continued when a black or whitelist was used, regardless of if the [callback](https://github.com/rubycdp/cuprite/blob/master/lib/capybara/cuprite/page.rb#L137-L157) that applies the white/blacklist was the last callback. This prohibited callbacks registered after cuprite's from aborting the request or responding to it, since it was already continued.
2. Whitelists and blacklists could not be combined. If a blacklist was configured, the whitelist was never considered, and the request was [either aborted or continued](https://github.com/rubycdp/cuprite/blob/master/lib/capybara/cuprite/page.rb#L139-L143) based on if it matched the blacklist or not.

The [callback](https://github.com/jimryan/cuprite/blob/4e91fa937cd06cefdd36bf7398aa9aca7a449076/lib/capybara/cuprite/page.rb#L137-L148) that applies the black/whitelist now:
1. Aborts the request and stops if the blacklist is configured and the request matches it.
2. Aborts the request and stops if the whitelist is configured and the request does not match it.
3. Continues the request if there are no other callbacks.
4. Does nothing if the request does not match the blacklist, matches the whitelist, and there are other callbacks.

I also question if continuing the request should be the callback's responsibility or not, or if Ferrum should just continue it if no callbacks responded or aborted. As things stand, all callbacks need to do something like [this](https://github.com/jimryan/cuprite/blob/4e91fa937cd06cefdd36bf7398aa9aca7a449076/lib/capybara/cuprite/page.rb#L144-L147).

-----

Thank you so much for cuprite/ferrum, my test suites run faster, are easier to debug, and I actually understand what's going on and can read the code powering the entire stack. Awesome work ❤️ 