### PR TITLE
Check Ferrum::NodeNotFoundError to force Capybara reruns

### DIFF
--- a/lib/capybara/cuprite/driver.rb
+++ b/lib/capybara/cuprite/driver.rb
@@ -359,7 +359,8 @@ module Capybara::Cuprite
     def invalid_element_errors
       [Capybara::Cuprite::ObsoleteNode,
        Capybara::Cuprite::MouseEventFailed,
-       Ferrum::NoExecutionContextError]
+       Ferrum::NoExecutionContextError,
+       Ferrum::NodeNotFoundError]
     end
 
     def go_back


### PR DESCRIPTION
See https://github.com/rubycdp/cuprite/pull/125

Please merge this approach. It definitely works for me and feels better.