### PR TITLE
MouseEventFailed is warning by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ end
 * options `Hash`
   * `:url_blacklist` (Array) - array of strings to match against requested URLs
   * `:url_whitelist` (Array) - array of strings to match against requested URLs
+  * `:on_mouse_event_failed` (Symbol) - any of `:raise`, `:silence`, default `:warn`.
 
 
 ## Debugging

--- a/lib/capybara/cuprite/browser.rb
+++ b/lib/capybara/cuprite/browser.rb
@@ -10,12 +10,13 @@ module Capybara::Cuprite
                 find_modal accept_confirm dismiss_confirm accept_prompt
                 dismiss_prompt reset_modals] => :page
 
-    attr_reader :url_blacklist, :url_whitelist
+    attr_reader :url_blacklist, :url_whitelist, :on_mouse_event_failed
 
     def initialize(options = nil)
       options ||= {}
       self.url_blacklist = options[:url_blacklist]
       self.url_whitelist = options[:url_whitelist]
+      self.on_mouse_event_failed = options[:on_mouse_event_failed]
 
       super
       @page = false
@@ -44,6 +45,14 @@ module Capybara::Cuprite
     def url_blacklist=(patterns)
       @url_blacklist = prepare_wildcards(patterns)
       page.network.intercept if @client && !@url_blacklist.empty?
+    end
+
+    def on_mouse_event_failed=(setting = :warn)
+      valid_settings = %i[raise silence warn]
+      if !valid_settings.include?(setting)
+        raise "on_mouse_event_failed config must be one of: #{valid_settings}"
+      end
+      @on_mouse_event_failed = setting
     end
 
     def visit(*args)

--- a/lib/capybara/cuprite/browser.rb
+++ b/lib/capybara/cuprite/browser.rb
@@ -47,7 +47,8 @@ module Capybara::Cuprite
       page.network.intercept if @client && !@url_blacklist.empty?
     end
 
-    def on_mouse_event_failed=(setting = :warn)
+    def on_mouse_event_failed=(setting)
+      setting ||= :warn
       valid_settings = %i[raise silence warn]
       if !valid_settings.include?(setting)
         raise "on_mouse_event_failed config must be one of: #{valid_settings}"
@@ -178,6 +179,15 @@ module Capybara::Cuprite
 
     def all_text(node)
       node.text
+    end
+
+    def notify_silenceable_exception(exception)
+      case on_mouse_event_failed
+      when :raise
+        raise exception
+      when :warn
+        warn(exception.message)
+      end
     end
 
     private

--- a/lib/capybara/cuprite/driver.rb
+++ b/lib/capybara/cuprite/driver.rb
@@ -154,6 +154,7 @@ module Capybara::Cuprite
       @paper_size = nil
       browser.url_blacklist = @options[:url_blacklist]
       browser.url_whitelist = @options[:url_whitelist]
+      browser.on_mouse_event_failed = @options[:on_mouse_event_failed]
       browser.reset
       @started = false
     end

--- a/lib/capybara/cuprite/driver.rb
+++ b/lib/capybara/cuprite/driver.rb
@@ -461,5 +461,14 @@ module Capybara::Cuprite
       (path && File.extname(path).delete(".") == "pdf") ||
       options[:format].to_s == "pdf"
     end
+
+    def notify_silenceable_exception(exception)
+      case on_mouse_event_failed
+      when :raise
+        raise exception
+      when :warn
+        warn(exception.message)
+      end
+    end
   end
 end

--- a/lib/capybara/cuprite/driver.rb
+++ b/lib/capybara/cuprite/driver.rb
@@ -461,14 +461,5 @@ module Capybara::Cuprite
       (path && File.extname(path).delete(".") == "pdf") ||
       options[:format].to_s == "pdf"
     end
-
-    def notify_silenceable_exception(exception)
-      case on_mouse_event_failed
-      when :raise
-        raise exception
-      when :warn
-        warn(exception.message)
-      end
-    end
   end
 end

--- a/lib/capybara/cuprite/node.rb
+++ b/lib/capybara/cuprite/node.rb
@@ -9,7 +9,7 @@ module Capybara::Cuprite
     extend Forwardable
 
     delegate %i(description) => :node
-    delegate %i(browser) => :driver
+    delegate %i(browser notify_silenceable_exception) => :driver
 
     def initialize(driver, node)
       super(driver, self)
@@ -23,7 +23,7 @@ module Capybara::Cuprite
     rescue Ferrum::BrowserError => e
       case e.message
       when "Cuprite.MouseEventFailed"
-        raise MouseEventFailed.new(self, e.response)
+        notify_silenceable_exception(MouseEventFailed.new(self, e.response))
       else
         raise
       end

--- a/lib/capybara/cuprite/node.rb
+++ b/lib/capybara/cuprite/node.rb
@@ -9,7 +9,7 @@ module Capybara::Cuprite
     extend Forwardable
 
     delegate %i(description) => :node
-    delegate %i(browser notify_silenceable_exception) => :driver
+    delegate %i(browser) => :driver
 
     def initialize(driver, node)
       super(driver, self)
@@ -23,7 +23,7 @@ module Capybara::Cuprite
     rescue Ferrum::BrowserError => e
       case e.message
       when "Cuprite.MouseEventFailed"
-        notify_silenceable_exception(MouseEventFailed.new(self, e.response))
+        browser.notify_silenceable_exception(MouseEventFailed.new(self, e.response))
       else
         raise
       end

--- a/lib/capybara/cuprite/page.rb
+++ b/lib/capybara/cuprite/page.rb
@@ -103,7 +103,7 @@ module Capybara::Cuprite
       evaluate_on(node: node, expression: "_cuprite.mouseEventTest(this, '#{name}', #{x}, #{y})")
       true
     rescue Ferrum::JavaScriptError => e
-      raise MouseEventFailed.new(e.message) if e.class_name == "MouseEventFailed"
+      notify_silenceable_exception(MouseEventFailed.new(e.message)) if e.class_name == "MouseEventFailed"
     end
 
     def switch_to_frame(handle)
@@ -183,7 +183,7 @@ module Capybara::Cuprite
       x, y = node.find_position(**options)
     rescue Ferrum::BrowserError => e
       if e.message == "Could not compute content quads."
-        raise MouseEventFailed.new("MouseEventFailed: click, none, 0, 0")
+        notify_silenceable_exception(MouseEventFailed.new("MouseEventFailed: click, none, 0, 0"))
       else
         raise
       end

--- a/lib/capybara/cuprite/page.rb
+++ b/lib/capybara/cuprite/page.rb
@@ -103,7 +103,7 @@ module Capybara::Cuprite
       evaluate_on(node: node, expression: "_cuprite.mouseEventTest(this, '#{name}', #{x}, #{y})")
       true
     rescue Ferrum::JavaScriptError => e
-      notify_silenceable_exception(MouseEventFailed.new(e.message)) if e.class_name == "MouseEventFailed"
+      browser.notify_silenceable_exception(MouseEventFailed.new(e.message)) if e.class_name == "MouseEventFailed"
     end
 
     def switch_to_frame(handle)
@@ -183,7 +183,7 @@ module Capybara::Cuprite
       x, y = node.find_position(**options)
     rescue Ferrum::BrowserError => e
       if e.message == "Could not compute content quads."
-        notify_silenceable_exception(MouseEventFailed.new("MouseEventFailed: click, none, 0, 0"))
+        browser.notify_silenceable_exception(MouseEventFailed.new("MouseEventFailed: click, none, 0, 0"))
       else
         raise
       end

--- a/spec/features/session_spec.rb
+++ b/spec/features/session_spec.rb
@@ -80,9 +80,37 @@ describe Capybara::Session do
           @session.visit("/cuprite/with_js")
         end
 
-        it "raises a MouseEventFailed error" do
-          expect { @session.click_link("O hai") }
-            .to raise_error(Capybara::Cuprite::MouseEventFailed)
+        context "if on_mouse_event_failed set to warn" do
+          before do
+            @session.driver.browser.on_mouse_event_failed = :silence
+          end
+
+          it "does not warn or raise" do
+            expect(@session.driver.browser).not_to receive(:warn)
+            @session.click_link("O hai")
+          end
+        end
+
+        context "if on_mouse_event_failed set to raise" do
+          before do
+            @session.driver.browser.on_mouse_event_failed = :raise
+          end
+
+          it "raises a MouseEventFailed error" do
+            expect { @session.click_link("O hai") }
+              .to raise_error(Capybara::Cuprite::MouseEventFailed)
+          end
+        end
+
+        context "if on_mouse_event_failed set to warn" do
+          before do
+            @session.driver.browser.on_mouse_event_failed = :warn
+          end
+
+          it "warns insated of raises" do
+            expect(@session.driver.browser).to receive(:warn)
+            @session.click_link("O hai")
+          end
         end
 
         context "and is then brought in" do
@@ -418,6 +446,7 @@ describe Capybara::Session do
 
       context "with #two overlapping #one" do
         before do
+          @session.driver.browser.on_mouse_event_failed = :raise
           @session.execute_script <<-JS
             var two = document.getElementById("two")
             two.style.position = "absolute"
@@ -456,6 +485,7 @@ describe Capybara::Session do
 
       context "with #svg overlapping #one" do
         before do
+          @session.driver.browser.on_mouse_event_failed = :raise
           @session.execute_script <<-JS
             var two = document.getElementById("svg")
             two.style.position = "absolute"


### PR DESCRIPTION
Closes https://github.com/rubycdp/cuprite/issues/135

Seems the most flexible and useful way to configure this going forward is having all 3 settings.