### PR TITLE
Improve documentation on user agent strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Manipulate HTTP request headers like a boss:
 page.driver.headers # => {}
 page.driver.headers = { "Host" => "github.com" }
 page.driver.add_headers("Referer" => "https://example.com")
-page.driver.headers # => { "User-Agent" => "Cuprite", "Host" => "https://github.com" }
+page.driver.headers # => { "User-Agent" => "Cuprite", "Host" => "https://github.com", "Referer" => "https://example.com" }
 ```
 
 Notice that `headers=` will overwrite already set headers. You should use

--- a/README.md
+++ b/README.md
@@ -108,6 +108,15 @@ opened where you can further experiment with the test.
 * `page.driver.scroll_to(left, top)` Scroll to a given position.
 * `element.send_keys(*keys)` Send keys to a given node.
 
+## Set user agent
+
+To change the user-agent of the driver for all following requests, use the `user-agent` browser option:
+
+```
+Capybara::Cuprite::Driver.new(app, { browser_options: { 'user-agent': 'Your own user agent string' } })
+```
+
+If you want to change the user-agent for one request, you can use the request headers.
 
 ## Request headers
 
@@ -115,9 +124,9 @@ Manipulate HTTP request headers like a boss:
 
 ``` ruby
 page.driver.headers # => {}
-page.driver.headers = { "User-Agent" => "Cuprite" }
+page.driver.headers = { "Host" => "github.com" }
 page.driver.add_headers("Referer" => "https://example.com")
-page.driver.headers # => { "User-Agent" => "Cuprite", "Referer" => "https://example.com" }
+page.driver.headers # => { "User-Agent" => "Cuprite", "Host" => "https://github.com" }
 ```
 
 Notice that `headers=` will overwrite already set headers. You should use


### PR DESCRIPTION
In our test suite, we also test with mobile user agents. We do this by creating several different drivers with different user agents. Coming from Selenium, I was used to set the user agent in the browser options. With no mention of the `user-agent` option in the Ferrum or Cuprite documentation, I assumed we needed to use headers:

```
driver = Capybara::Cuprite::Driver.new(app)
driver.add_header("User-Agent", "...")
```

This works fine for the first request in the driver, but subsequent requests fail due to the reset of the headers. I found out the `user-agent` browser option still works fine. I think it is worth a mention in the README so other developers also know how to set the right user-agent string for their drivers.