### PR TITLE
Fix ruby warning

### DIFF
--- a/lib/capybara/cuprite/page.rb
+++ b/lib/capybara/cuprite/page.rb
@@ -180,7 +180,7 @@ module Capybara::Cuprite
     end
 
     def find_position(node, **options)
-      x, y = node.find_position(**options)
+      node.find_position(**options)
     rescue Ferrum::BrowserError => e
       if e.message == "Could not compute content quads."
         raise MouseEventFailed.new("MouseEventFailed: click, none, 0, 0")


### PR DESCRIPTION
This fixes following warning.

```
cuprite-0.13/lib/capybara/cuprite/page.rb:183: warning: assigned but unused variable - x
cuprite-0.13/lib/capybara/cuprite/page.rb:183: warning: assigned but unused variable - y
```