### PR TITLE
implement Browser#drag and #drag_by.

### DIFF
--- a/lib/capybara/cuprite/browser.rb
+++ b/lib/capybara/cuprite/browser.rb
@@ -113,11 +113,23 @@ module Capybara
       end
 
       def drag(node, other)
-        raise NotImplementedError
+        x1, y1 = node.find_position
+        x2, y2 = other.find_position
+
+        mouse.move(x: x1, y: y1)
+        mouse.down
+        mouse.move(x: x2, y: y2)
+        mouse.up
       end
 
       def drag_by(node, x, y)
-        raise NotImplementedError
+        x1, y1 = node.find_position
+        x2, y2 = x1 + x, y1 + y
+
+        mouse.move(x: x1, y: y1)
+        mouse.down
+        mouse.move(x: x2, y: y2)
+        mouse.up
       end
 
       def select_file(node, value)

--- a/lib/capybara/cuprite/node.rb
+++ b/lib/capybara/cuprite/node.rb
@@ -160,7 +160,7 @@ module Capybara
       end
 
       def drag_to(other)
-        command(:drag, other)
+        command(:drag, other.node)
       end
 
       def drag_by(x, y)

--- a/spec/features/session_spec.rb
+++ b/spec/features/session_spec.rb
@@ -575,7 +575,7 @@ describe Capybara::Session do
       end
     end
 
-    context "dragging support", skip: true do
+    context "dragging support" do
       before do
         @session.visit "/cuprite/drag"
       end


### PR DESCRIPTION
Closes #67.

Previously skipped "dragging support" tests now pass without changes, and my drag-and-drop tests that were passing in Selenium pass with Cuprite now.

Thoughts?