### PR TITLE
Support `steps`  option for dragging

### DIFF
--- a/lib/capybara/cuprite/browser.rb
+++ b/lib/capybara/cuprite/browser.rb
@@ -112,24 +112,24 @@ module Capybara
         raise NotImplementedError
       end
 
-      def drag(node, other)
+      def drag(node, other, steps)
         x1, y1 = node.find_position
         x2, y2 = other.find_position
 
         mouse.move(x: x1, y: y1)
         mouse.down
-        mouse.move(x: x2, y: y2)
+        mouse.move(x: x2, y: y2, steps: steps)
         mouse.up
       end
 
-      def drag_by(node, x, y)
+      def drag_by(node, x, y, steps)
         x1, y1 = node.find_position
         x2 = x1 + x
         y2 = y1 + y
 
         mouse.move(x: x1, y: y1)
         mouse.down
-        mouse.move(x: x2, y: y2)
+        mouse.move(x: x2, y: y2, steps: steps)
         mouse.up
       end
 

--- a/lib/capybara/cuprite/node.rb
+++ b/lib/capybara/cuprite/node.rb
@@ -159,12 +159,16 @@ module Capybara
         command(:hover)
       end
 
-      def drag_to(other)
-        command(:drag, other.node)
+      def drag_to(other, **options)
+        options[:steps] ||= 1
+
+        command(:drag, other.node, options[:steps])
       end
 
-      def drag_by(x, y)
-        command(:drag_by, x, y)
+      def drag_by(x, y, **options)
+        options[:steps] ||= 1
+
+        command(:drag_by, x, y, options[:steps])
       end
 
       def trigger(event)


### PR DESCRIPTION
I've been trying to get a system test working with https://sortablejs.github.io/Sortable/

I had to do two things:

- Change the sortable `forceFallback` config to `true`: this is an application level change to not use HTML native drag and drop and use a different event fallback
- Add `steps` to the `mouse.move` calls

This PR adds an option to pass `steps` to use when dragging in case you need to more closely simulate dragging the mouse across the browser (vs the current "teleport" behavior)