### PR TITLE
Fix spec helper on MacOS

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ CUPRITE_ROOT = File.expand_path("..", __dir__)
 $LOAD_PATH.unshift("#{CUPRITE_ROOT}/lib")
 
 require "fileutils"
+require "shellwords"
 require "bundler/setup"
 require "rspec"
 
@@ -15,7 +16,7 @@ require "support/external_browser"
 
 puts ""
 command = Ferrum::Browser::Command.build({ window_size: [], ignore_default_browser_options: true }, nil)
-puts `#{command.to_a.first} --version`
+puts `#{Shellwords.escape(command.path)} --version`
 puts ""
 
 Capybara.register_driver(:cuprite) do |app|


### PR DESCRIPTION
If the detected path to Chrome includes spaces (which it does by default on MacOS) then the version logging in `spec/spec_helper.rb` would fail, preventing the test suite from running.

Running the following command: `bundle exec rspec --dry-run`

## Before

```
An error occurred while loading spec_helper.
Failure/Error: puts `#{command.to_a.first} --version`

Errno::ENOENT:
  No such file or directory - /Applications/Google
# ./spec/spec_helper.rb:18:in ``'
# ./spec/spec_helper.rb:18:in `<top (required)>'
No examples found.
No examples found.


Finished in 0.00002 seconds (files took 0.36901 seconds to load)
0 examples, 0 failures, 1 error occurred outside of examples

Finished in 0.00002 seconds (files took 0.36901 seconds to load)
0 examples, 0 failures, 1 error occurred outside of examples
```

## After

```
Google Chrome 99.0.4844.51

[...]

Finished in 0.0431 seconds (files took 1.03 seconds to load)
1751 examples, 0 failures, 59 pending
```

## Suggested fix

[`Shellwords.escape`](https://ruby-doc.org/stdlib-3.1.0/libdoc/shellwords/rdoc/Shellwords.html#method-c-escape) escapes the spaces:

```
Shellwords.escape("/Applications/Google Chrome.app/Contents/MacOS/Google Chrome") # => "/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome"
```