### PR TITLE
run 'bundle exec rubocop -A' to fix latest master build

### DIFF
--- a/spec/features/driver_spec.rb
+++ b/spec/features/driver_spec.rb
@@ -324,7 +324,7 @@ module Capybara
 
         def create_screenshot(file, *args)
           image = @driver.render_base64(format, *args)
-          File.open(file, "wb") { |f| f.write Base64.decode64(image) }
+          File.binwrite(file, Base64.decode64(image))
         end
 
         it "supports rendering the page in base64" do

--- a/spec/features/session_spec.rb
+++ b/spec/features/session_spec.rb
@@ -231,7 +231,7 @@ describe Capybara::Session do
 
       it "attaches a file when passed a Pathname" do
         filename = Pathname.new("spec/tmp/a_test_pathname").expand_path
-        File.open(filename, "w") { |f| f.write("text") }
+        File.write(filename, "text")
 
         element = @session.find(:css, "#change_me_file")
         element.set(filename)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -120,7 +120,7 @@ RSpec.configure do |config|
 
   def save_exception_log(browser, filename, line_number, timestamp)
     log_name = "logfile-#{filename}-#{line_number}-#{timestamp}.txt"
-    File.open("/tmp/cuprite/#{log_name}", "wb") { |f| f.write(browser.logger.string) }
+    File.binwrite("/tmp/cuprite/#{log_name}", browser.logger.string)
   rescue StandardError => e
     puts "#{e.class}: #{e.message}"
   end


### PR DESCRIPTION
https://github.com/rubycdp/cuprite/runs/5832487369?check_suite_focus=true
caused by updated rubocop:
`rubocop 1.26.1 (was 1.23)`