### PR TITLE
Support custom save_path option

### DIFF
--- a/lib/capybara/cuprite/driver.rb
+++ b/lib/capybara/cuprite/driver.rb
@@ -33,7 +33,7 @@ module Capybara
         @screen_size = @options.delete(:screen_size)
         @screen_size ||= DEFAULT_MAXIMIZE_SCREEN_SIZE
 
-        @options[:save_path] = Capybara.save_path.to_s if Capybara.save_path
+        @options[:save_path] ||= Capybara.save_path.to_s if Capybara.save_path
 
         ENV["FERRUM_DEBUG"] = "true" if ENV["CUPRITE_DEBUG"]
 

--- a/spec/lib/driver_spec.rb
+++ b/spec/lib/driver_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+describe Capybara::Cuprite::Driver do
+  describe "save_path configuration" do
+    it "defaults to the Capybara save path" do
+      driver = with_capybara_save_path("/tmp/capybara-save-path") do
+        described_class.new(nil)
+      end
+
+      expect(driver.browser.options).to include(save_path: "/tmp/capybara-save-path")
+    end
+
+    it "allows a custom path to be specified" do
+      custom_path = Dir.mktmpdir
+
+      driver = with_capybara_save_path("/tmp/capybara-save-path") do
+        described_class.new(nil, { save_path: custom_path })
+      end
+
+      expect(driver.browser.options).to include(save_path: custom_path)
+    end
+  end
+
+  private
+
+  def with_capybara_save_path(path)
+    original_capybara_save_path = Capybara.save_path
+    Capybara.save_path = path
+    yield
+  ensure
+    Capybara.save_path = original_capybara_save_path
+  end
+end


### PR DESCRIPTION
This PR allows a custom `save_path` option to be configured, instead of defaulting to the `Capybara.save_path`.

The motivation is wanting to specify an ephemeral directory for downloads (PDFs, CSVs etc) which is cleared between tests, but keep other items saved to the `Capybara.save_path` (like screenshots) as CI artifacts.