### PR TITLE
Allow to pass save_path to driver

### DIFF
--- a/lib/capybara/cuprite/driver.rb
+++ b/lib/capybara/cuprite/driver.rb
@@ -33,7 +33,7 @@ module Capybara
         @screen_size = @options.delete(:screen_size)
         @screen_size ||= DEFAULT_MAXIMIZE_SCREEN_SIZE
 
-        @options[:save_path] = Capybara.save_path.to_s if Capybara.save_path
+        @options[:save_path] ||= Capybara.save_path.to_s if Capybara.save_path
 
         ENV["FERRUM_DEBUG"] = "true" if ENV["CUPRITE_DEBUG"]
 


### PR DESCRIPTION
I want to specify where filed are being downloaded. Defaulting to
Capybara.save_path is probably an okay default but then the downloads
and screenshots are mixed.

With this change you can pass save_path to driver initiation.
```
Capybara::Cuprite::Driver.new(app, save_path: "tmp/capybara/downloads")
```

An alternative would be to manually send the command to move
download path.
```
driver.browser.page.command(
  "Page.setDownloadBehavior",
  behavior: "allow",
  downloadPath: "tmp/capybara/simons"
)
```

related to #181

We use it for spec and have a helper module which looks like this. Would you like to include it in cuprite? I think not since you probably want downloads for this tab/page not all downloads
```ruby
# source:  https://stackoverflow.com/a/29544674
module DownloadHelpers
  TIMEOUT = 5
  PATH    = Rails.root.join("tmp/capybara/downloads")

  module_function

  def list_downloads
    Dir[PATH.join("*")]
  end

  def only_download
    list_downloads
      .tap { |downloads| raise <<~ERROR if downloads.size > 1 }
        DownloadHelpers#only_download excpects there to only be one download,
        maybe someone isn't clearing downloads after their spec?
        DownloadHelpers.clear_downloads will do the trick
      ERROR
      .first
  end

  def only_download_content
    wait_for_download
    File.read(only_download)
  end

  def wait_for_download
    Timeout.timeout(TIMEOUT) do
      sleep 0.1 until downloaded?
    end
  end

  def downloaded?
    !downloading? && list_downloads.any?
  end

  def downloading?
    list_downloads.grep(/\.crdownload$/).any?
  end

  def clear_downloads
    FileUtils.rm_f(list_downloads)
  end
end
```