### PR TITLE
Skip injecting extensions on frame switch to prevent javascript errors

### DIFF
--- a/lib/capybara/cuprite/page.rb
+++ b/lib/capybara/cuprite/page.rb
@@ -116,7 +116,6 @@ module Capybara
           @frame_stack = []
         else
           @frame_stack << handle
-          inject_extensions
         end
       end
 

--- a/spec/features/session_spec.rb
+++ b/spec/features/session_spec.rb
@@ -826,6 +826,18 @@ describe Capybara::Session do
           expect(e).to be_a(Capybara::ElementNotFound)
         end)
       end
+
+      it "generates no javascript errors when switching into a frame" do
+        @driver.browser.evaluate_on_new_document(
+          "window.errors ||= []; window.onerror = function(msg) { window.errors += msg; };"
+        )
+
+        @session.visit "/cuprite/frames"
+        @session.within_frame(0) do
+          expect(@session.evaluate_script("window.errors")).to be_empty
+        end
+        expect(@session.evaluate_script("window.errors")).to be_empty
+      end
     end
 
     it "handles obsolete node during an attach_file" do

--- a/spec/features/session_spec.rb
+++ b/spec/features/session_spec.rb
@@ -828,7 +828,7 @@ describe Capybara::Session do
       end
 
       it "generates no javascript errors when switching into a frame" do
-        @driver.browser.evaluate_on_new_document(
+        @session.driver.browser.evaluate_on_new_document(
           "window.errors ||= []; window.onerror = function(msg) { window.errors += msg; };"
         )
 


### PR DESCRIPTION
Fixes #200.

The extensions were injected again on every frame switch. That seemed unnecessary to me as they were already injected on page load by ferrum.
This resulted in some javascript errors, because some constants were redefined by the default cuprite extension.

This change fixes this problem and there does not seem to be anything missing inside the frames.