### PR TITLE
Fix files being part of the gem

### DIFF
--- a/cuprite.gemspec
+++ b/cuprite.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
                     "run your tests on a headless Chrome browser"
   s.license       = "MIT"
   s.require_paths = ["lib"]
-  s.files         = Dir["{lib}/**/*,LICENSE,README.md"]
+  s.files         = Dir["{lib}/**/*", "LICENSE", "README.md"]
   s.metadata = {
     "homepage_uri" => "https://cuprite.rubycdp.com/",
     "bug_tracker_uri" => "https://github.com/rubycdp/cuprite/issues",


### PR DESCRIPTION
This fixes the files being included in the gem. Release 0.14 is empty.

Fixes #211.

@route Would you mind releasing a new version with this fix? Thank you!