### PR TITLE
[0.14.3] Support custom save_path option

### DIFF
--- a/lib/capybara/cuprite/driver.rb
+++ b/lib/capybara/cuprite/driver.rb
@@ -32,8 +32,7 @@ module Capybara
 
         @screen_size = @options.delete(:screen_size)
         @screen_size ||= DEFAULT_MAXIMIZE_SCREEN_SIZE
-
-        @options[:save_path] = File.expand_path(Capybara.save_path) if Capybara.save_path
+        @options[:save_path] ||= File.expand_path(Capybara.save_path) if Capybara.save_path
 
         ENV["FERRUM_DEBUG"] = "true" if ENV["CUPRITE_DEBUG"]
 

--- a/spec/lib/driver_spec.rb
+++ b/spec/lib/driver_spec.rb
@@ -7,7 +7,7 @@ describe Capybara::Cuprite::Driver do
         described_class.new(nil)
       end
 
-      expect(driver.browser.options).to include(save_path: "/tmp/capybara-save-path")
+      expect(driver.browser.options.to_h).to include(save_path: "/tmp/capybara-save-path")
     end
 
     it "allows a custom path to be specified" do
@@ -17,7 +17,7 @@ describe Capybara::Cuprite::Driver do
         described_class.new(nil, { save_path: custom_path })
       end
 
-      expect(driver.browser.options).to include(save_path: custom_path)
+      expect(driver.browser.options.to_h).to include(save_path: custom_path)
     end
   end
 

--- a/spec/lib/driver_spec.rb
+++ b/spec/lib/driver_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+describe Capybara::Cuprite::Driver do
+  describe "save_path configuration" do
+    it "defaults to the Capybara save path" do
+      driver = with_capybara_save_path("/tmp/capybara-save-path") do
+        described_class.new(nil)
+      end
+
+      expect(driver.browser.options).to include(save_path: "/tmp/capybara-save-path")
+    end
+
+    it "allows a custom path to be specified" do
+      custom_path = Dir.mktmpdir
+
+      driver = with_capybara_save_path("/tmp/capybara-save-path") do
+        described_class.new(nil, { save_path: custom_path })
+      end
+
+      expect(driver.browser.options).to include(save_path: custom_path)
+    end
+  end
+
+  private
+
+  def with_capybara_save_path(path)
+    original_capybara_save_path = Capybara.save_path
+    Capybara.save_path = path
+    yield
+  ensure
+    Capybara.save_path = original_capybara_save_path
+  end
+end


### PR DESCRIPTION
Allows paths other than Capybara.save_path to be specified

This PR allows a custom save_path option to be configured, instead of defaulting to the Capybara.save_path.

The motivation is wanting to specify an ephemeral directory for downloads (PDFs, CSVs etc) which is cleared between tests, but keep other items saved to the Capybara.save_path (like screenshots) as CI artifacts.

This is especially useful when running multiple specs on a single instance. Here is how we separate the downloads using this patch:

```ruby
module Downloads
  def downloads_path
    Rails.root.join("log", "capybara", "downloads", ENV.fetch("TEST_ENV_NUMBER", "1"))
  end
end

...
...

cuprite_options = {
  process_timeout: 60,
  ...
  save_path: Downloads.downloads_path,
}

...

Capybara.register_driver :cuprite_chrome do |app|
  Capybara::Cuprite::Driver.new(app, options)
end
```


Original PR: https://github.com/rubycdp/cuprite/pull/192 (this one has just rebased against 0.14.3)