### PR TITLE
Update official actions used in workflows

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       BUNDLE_GEMFILE: .github/gemfiles/${{ matrix.gemfile }}.gemfile
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -39,7 +39,7 @@ jobs:
         run: bundle exec rake
 
       - name: Archive artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:
           name: footprints


### PR DESCRIPTION
Just a quick PR to do some tidy up 😃 

- fixes deprecation warnings for: "Node.js 12 actions are deprecated" shown as annotations on a run:


<img width="1095" alt="image" src="https://user-images.githubusercontent.com/16309691/202201404-e09607e5-8e41-48d9-a607-ccd540755a34.png">

