### PR TITLE
add: `Driver#execute_async_script`

### DIFF
--- a/lib/capybara/cuprite/driver.rb
+++ b/lib/capybara/cuprite/driver.rb
@@ -95,6 +95,11 @@ module Capybara
         nil
       end
 
+      def execute_async_script(script, *args)
+        browser.evaluate_async(script, session_wait_time, *native_args(args))
+        nil
+      end
+
       def switch_to_frame(locator)
         handle = case locator
                  when Capybara::Node::Element

--- a/spec/features/driver_spec.rb
+++ b/spec/features/driver_spec.rb
@@ -1540,6 +1540,24 @@ module Capybara
         end
       end
 
+      context "execute_async_script" do
+        it "handles execute_async_script value properly" do
+          @session.using_wait_time(5) do
+            expect(@session.driver.execute_async_script("arguments[0]('ignored')")).to be_nil
+          end
+        end
+
+        it "will timeout" do
+          @session.using_wait_time(1) do
+            expect do
+              @session.driver.execute_async_script <<~JS
+                var callback=arguments[0]; setTimeout(function(){callback()}, 4000)
+              JS
+            end.to raise_error Ferrum::ScriptTimeoutError
+          end
+        end
+      end
+
       it "can get the frames url" do
         @session.visit "/cuprite/frames"
 


### PR DESCRIPTION
Implements the `Capybara::Cuprite::Driver#execute_async_script` as a corollary to `#execute_script` and the
`#evaluate_script`-`#evaluate_async_script` pairing.

Draws inspiration from other drivers, for example, from the [selenium-webdriver][] implementation.

[selenium-webdriver]: https://github.com/SeleniumHQ/selenium/blob/9c771a1e2f629265005d60e55ece76281e42d8bc/rb/lib/selenium/webdriver/common/driver.rb#L232-L249