### PR TITLE
Remember parentNode in case onChange callback mutates DOM

### DIFF
--- a/lib/capybara/cuprite/javascripts/index.js
+++ b/lib/capybara/cuprite/javascripts/index.js
@@ -356,12 +356,13 @@ class Cuprite {
     } else if (value == false && !node.parentNode.multiple) {
       return false;
     } else {
-      this.trigger(node.parentNode, "focus");
+      let parentNode = node.parentNode;
+      this.trigger(parentNode, "focus");
 
       node.selected = value;
       this.changed(node);
 
-      this.trigger(node.parentNode, "blur");
+      this.trigger(parentNode, "blur");
       return true;
     }
   }


### PR DESCRIPTION
There's no guarantee that the onChange callback won't mutate the DOM in some way that removes the selected option node, thus creating a runtime error when null.dispatchEvent is called when trying to trigger the "blur" event on the parent. By saving the parentNode in a variable, we avoid this edge-case scenario.