### PR TITLE
Fire input and change event on set for color input

### DIFF
--- a/lib/capybara/cuprite/node.rb
+++ b/lib/capybara/cuprite/node.rb
@@ -103,6 +103,8 @@ module Capybara
             command(:select_file, files)
           when "color"
             node.evaluate("this.setAttribute('value', '#{value}')")
+            node.evaluate("this.dispatchEvent(new InputEvent('input'))")
+            node.evaluate("this.dispatchEvent(new Event('change', { bubbles: true }))")
           else
             command(:set, value.to_s)
           end

--- a/spec/features/session_spec.rb
+++ b/spec/features/session_spec.rb
@@ -245,6 +245,18 @@ describe Capybara::Session do
         element.set("#ddeeff")
         expect(element.value).to eq("#ddeeff")
       end
+
+      it "fires the change event for a color input" do
+        element = @session.find(:css, "#change_me_color")
+        element.set("#ddeeff")
+        expect(@session.find(:css, "#changes").text).to eq("#ddeeff")
+      end
+
+      it "fires the input event for a color input" do
+        element = @session.find(:css, "#change_me_color")
+        element.set("#ddeeff")
+        expect(@session.find(:css, "#changes_on_input").text).to eq("#ddeeff")
+      end
     end
 
     describe "Node#visible" do

--- a/spec/support/public/test.js
+++ b/spec/support/public/test.js
@@ -34,6 +34,14 @@ $(function() {
       $("#changes_on_blur").text("Blur")
     })
 
+  $("#change_me_color")
+    .change(function(event) {
+      $("#changes").text($(this).val())
+    })
+    .bind("input", function(event) {
+      $("#changes_on_input").text($(this).val())
+    })
+
   $("#browser")
     .change(function(event) {
       $("#changes").text($(this).val())


### PR DESCRIPTION
Since a color input has to have its value set directly via javascript (presumably because of the difficulty of interacting with the browser's colour picker), the `change` and `input` events don't automatically happen. This PR fires them manually.

Fixes rubycdp/cuprite#229