### PR TITLE
Add initial support for shadow_root

### DIFF
--- a/lib/capybara/cuprite/javascripts/index.js
+++ b/lib/capybara/cuprite/javascripts/index.js
@@ -52,13 +52,17 @@ class Cuprite {
     if (this.isVisible(node)) {
       if (node.nodeName == "TEXTAREA") {
         return node.textContent;
-      } else {
-        if (node instanceof SVGElement) {
-          return node.textContent;
-        } else {
-          return node.innerText;
-        }
       }
+      if (node instanceof SVGElement) {
+        return node.textContent;
+      }
+      if (node instanceof ShadowRoot) {
+        return Array.from(node.children)
+          .map(child => this.visibleText(child))
+          .filter(text => text)
+          .join(" ");
+      }
+      return node.innerText;
     }
   }
 
@@ -74,11 +78,15 @@ class Cuprite {
     }
 
     while (node) {
-      style = window.getComputedStyle(node);
-      if (style.display === "none" || style.visibility === "hidden" || parseFloat(style.opacity) === 0) {
-        return false;
+      if (node instanceof ShadowRoot) {
+        node = node.host;
+      } else {
+        style = window.getComputedStyle(node);
+        if (style.display === "none" || style.visibility === "hidden" || parseFloat(style.opacity) === 0) {
+          return false;
+        }
+        node = node.parentElement ?? (node.getRootNode() instanceof ShadowRoot && node.getRootNode());
       }
-      node = node.parentElement;
     }
 
     return true;
@@ -95,6 +103,10 @@ class Cuprite {
   }
 
   path(node) {
+    if (node.getRootNode && node.getRootNode() instanceof ShadowRoot) {
+      return "(: Shadow DOM element - no XPath :)";
+    };
+
     let nodes = [node];
     let parent = node.parentNode;
     while (parent !== document && parent !== null) {
@@ -275,7 +287,7 @@ class Cuprite {
     x -= frameOffset.left;
     y -= frameOffset.top;
 
-    let element = document.elementFromPoint(x, y);
+    let element = node.getRootNode().elementFromPoint(x, y);
 
     let el = element;
     while (el) {

--- a/lib/capybara/cuprite/node.rb
+++ b/lib/capybara/cuprite/node.rb
@@ -211,6 +211,13 @@ module Capybara
         command(:path)
       end
 
+      def shadow_root
+        root = driver.evaluate_script <<~JS, self
+          arguments[0].shadowRoot
+        JS
+        root && self.class.new(driver, root.node)
+      end
+
       def inspect
         %(#<#{self.class} @node=#{@node.inspect}>)
       end

--- a/spec/features/session_spec.rb
+++ b/spec/features/session_spec.rb
@@ -316,6 +316,24 @@ describe Capybara::Session do
       end
     end
 
+    describe "Node#shadow_root" do
+      it "produces error messages when failing" do
+        @session.visit("/with_shadow")
+        shadow_root = @session.find(:css, "#shadow_host").shadow_root
+        expect do
+          expect(shadow_root).to have_css("#shadow_content", text: "Not in the document")
+        end.to raise_error(/tag="#document-fragment"/)
+      end
+
+      it "extends visibility check across shadow host boundary" do
+        @session.visit("/with_shadow")
+        shadow_root = @session.find(:css, "#shadow_host").shadow_root
+        expect(shadow_root).to have_css("a")
+        @session.execute_script %(document.getElementById("shadow_host").style.display = "none")
+        expect(shadow_root).to_not have_css("a")
+      end
+    end
+
     it "has no trouble clicking elements when the size of a document changes" do
       @session.visit("/cuprite/long_page")
       @session.find(:css, "#penultimate").click

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -64,7 +64,7 @@ RSpec.configure do |config|
       node #visible? details non-summary descendants should be non-visible
       node #visible? works when details is toggled open and closed
       node #path reports when element in shadow dom
-      node #shadow_root
+      node #shadow_root should produce error messages when failing
       #all with obscured filter should only find nodes on top in the viewport when false
       #all with obscured filter should not find nodes on top outside the viewport when false
       #all with obscured filter should find top nodes outside the viewport when true


### PR DESCRIPTION
Capybara added support to access an element's shadow DOM with `Element#shadow_root` in https://github.com/teamcapybara/capybara/pull/2546 – it would be nice if Cuprite supported it too.

Here is an attempt at that. Not sure if it does everything as it should, but the specs are passing locally and I've used it successfully in a project's test suite where

```ruby
# this
expect(
  evaluate_script('arguments[0].shadowRoot', page.find('.a-shadow-host'))
).to have_selector('.inside-shadow-dom')

# could be replaced with this
expect(
  page.find('.a-shadow-host').shadow_root
).to have_selector('.inside-shadow-dom')
```

The spec "produces error messages when failing" provided by Capybara needed to be adapted because the generated error message includes the value of `tagName` which is different between Selenium and Cuprite.

The added spec "extends visibility check across shadow host boundary" covers a behaviour that Selenium implements this way: the visibility of the shadow propagates down to its children.
