### PR TITLE
Recent 0.14 release of Ferrum is causing Bundler to downgrade Cuprite 0.7.1

### DIFF
--- a/cuprite.gemspec
+++ b/cuprite.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.7.0"
 
   s.add_runtime_dependency "capybara", "~> 3.0"
-  s.add_runtime_dependency "ferrum",   "~> 0.13.0"
+  s.add_runtime_dependency "ferrum",   "~> 0.14.0"
 end

--- a/lib/capybara/cuprite/version.rb
+++ b/lib/capybara/cuprite/version.rb
@@ -2,6 +2,6 @@
 
 module Capybara
   module Cuprite
-    VERSION = "0.14.3"
+    VERSION = "0.14.4"
   end
 end


### PR DESCRIPTION
Hi folks!

We've noticed that Dependabot is trying to downgrade Cuprite to version 0.7.1 while trying to upgrade Ferrum to 0.14.
I assumed this was simply due to the rightmost version check bundler does with the `~>` operator and previous Cuprite version constraints.

Thank you!

---
<img width="826" alt="image" src="https://github.com/rubycdp/cuprite/assets/2131451/b5133af3-057f-46ec-9e53-518c6d855bf4">
