### PR TITLE
Send correct inputType when typing

### DIFF
--- a/lib/capybara/cuprite/javascripts/index.js
+++ b/lib/capybara/cuprite/javascripts/index.js
@@ -180,8 +180,7 @@ class Cuprite {
   }
 
   input(node) {
-    let event = document.createEvent("HTMLEvents");
-    event.initEvent("input", true, false);
+    let event = new InputEvent("input", { inputType: "insertText", bubbles: true, cancelable: false });
     node.dispatchEvent(event);
   }
 

--- a/spec/features/driver_spec.rb
+++ b/spec/features/driver_spec.rb
@@ -1470,6 +1470,11 @@ module Capybara
             expect(input.value).to eq("abc")
           end
 
+          it "uses the 'insertText' inputType for input event" do
+            input.set("a")
+            expect(output["data-input-type"]).to eq("insertText")
+          end
+
           it "doesn't call the change event if there is no change" do
             input.set("a")
             input.set("a")

--- a/spec/support/views/input_events.erb
+++ b/spec/support/views/input_events.erb
@@ -9,7 +9,10 @@
       const log = (s) => output.textContent = `${output.textContent} ${s}`
       input.addEventListener('keydown', () => log('keydown'))
       input.addEventListener('keypress', () => log('keypress'))
-      input.addEventListener('input', () => log('input'))
+      input.addEventListener('input', (event) => {
+        log('input');
+        output.dataset.inputType = event.inputType;
+      })
       input.addEventListener('keyup', () => log('keyup'))
       input.addEventListener('change', () => log('change'))
     </script>


### PR DESCRIPTION
When typing in an input field, the browser usually sends an input event with a specific `inputType`, e.g. `"insertText"` when adding characters, `"deleteContentBackward"` when backspacing, among others.

When using `set` or `fill_in` on a field, Cuprite is currently triggering the event in a way that leaves `inputType` as `undefined`, which is (unfortunately) what Chrome actually sends on autocompletion. The mostly correct way to trigger this event here should be with `"insertText"`.