### PR TITLE
Send instance of KeyboardEvent on keyup/keydown/keypress

### DIFF
--- a/lib/capybara/cuprite/javascripts/index.js
+++ b/lib/capybara/cuprite/javascripts/index.js
@@ -151,7 +151,7 @@ class Cuprite {
         // call the following functions in order, if one returns false (preventDefault),
         // stop the call chain
         [
-          () => this.keyupdowned(node, "keydown", keyCode),
+          () => this.keyupdowned(node, "keydown", char, keyCode),
           () => this.keypressed(node, false, false, false, false, char.charCodeAt(0), char.charCodeAt(0)),
           () => {
             this.setValue(node, node.value + char)
@@ -159,7 +159,7 @@ class Cuprite {
           }
         ].some(fn => fn())
 
-        this.keyupdowned(node, "keyup", keyCode);
+        this.keyupdowned(node, "keyup", char, keyCode);
       }
     }
 
@@ -187,11 +187,15 @@ class Cuprite {
   /**
    * @return {boolean} false when an event handler called preventDefault()
    */
-  keyupdowned(node, eventName, keyCode) {
-    let event = document.createEvent("UIEvents");
-    event.initEvent(eventName, true, true);
-    event.keyCode  = keyCode;
-    event.charCode = 0;
+  keyupdowned(node, eventName, char, keyCode) {
+    let event = new KeyboardEvent(
+      eventName, {
+        bubbles: true,
+        cancelable: true,
+        key: char,
+        keyCode: keyCode
+      }
+    );
     return !node.dispatchEvent(event);
   }
 
@@ -199,15 +203,18 @@ class Cuprite {
    * @return {boolean} false when an event handler called preventDefault()
    */
   keypressed(node, altKey, ctrlKey, shiftKey, metaKey, keyCode, charCode) {
-    event = document.createEvent("UIEvents");
-    event.initEvent("keypress", true, true);
-    event.window   = window;
-    event.altKey   = altKey;
-    event.ctrlKey  = ctrlKey;
-    event.shiftKey = shiftKey;
-    event.metaKey  = metaKey;
-    event.keyCode  = keyCode;
-    event.charCode = charCode;
+    let event = new KeyboardEvent(
+      "keypress", {
+        bubbles: true,
+        cancelable: true,
+        altKey: altKey,
+        ctrlKey: ctrlKey,
+        shiftKey: shiftKey,
+        metaKey: metaKey,
+        keyCode: keyCode,
+        charCode: charCode
+      }
+    );
     return !node.dispatchEvent(event);
   }
 


### PR DESCRIPTION
This PR changes the events sent on keyup/keydown/keypress to real instances of KeyboardEvent, instead of generic UIEvents.
This is closer to browser implementation and allows more reliable usage of third party tools like, for example, [Stimulus KeyboardEvent filters](https://stimulus.hotwired.dev/reference/actions#keyboardevent-filter).