### PR TITLE
Insert in type number the same way as strings

### DIFF
--- a/lib/capybara/cuprite/javascripts/index.js
+++ b/lib/capybara/cuprite/javascripts/index.js
@@ -128,7 +128,7 @@ class Cuprite {
     this.trigger(node, "focus");
     this.setValue(node, "");
 
-    if (node.type == "number" || node.type == "date" || node.type == "range") {
+    if (node.type == "date" || node.type == "range") {
       this.setValue(node, value);
       this.input(node);
     } else if (node.type == "time") {
@@ -145,8 +145,7 @@ class Cuprite {
       this.setValue(node, `${year}-${month}-${date}T${hour}:${min}:${sec}`);
       this.input(node);
     } else {
-      for (let i = 0; i < value.length; i++) {
-        let char = value[i];
+      for (let char of value.toString()) {
         let keyCode = this.characterToKeyCode(char);
         // call the following functions in order, if one returns false (preventDefault),
         // stop the call chain


### PR DESCRIPTION
When setting the value in an input of type number, set it the same way as a text, so that we get events(keydown, keypressed, keyup) for each "char" in the number when it is converted to a string