### PR TITLE
fix: correctly open the devtools

### DIFF
--- a/lib/capybara/cuprite/driver.rb
+++ b/lib/capybara/cuprite/driver.rb
@@ -265,7 +265,12 @@ module Capybara
       alias authorize basic_authorize
 
       def debug_url
-        "http://#{browser.process.host}:#{browser.process.port}"
+        response = JSON.parse(Net::HTTP.get(URI(build_remote_debug_url(path: "/json"))))
+
+        devtools_frontend_path = response[0]&.[]("devtoolsFrontendUrl")
+        raise "Could not generate debug url for remote debugging session" unless devtools_frontend_path
+
+        build_remote_debug_url path: devtools_frontend_path
       end
 
       def debug(binding = nil)
@@ -362,6 +367,10 @@ module Capybara
       end
 
       private
+
+      def build_remote_debug_url(path:)
+        "http://#{browser.process.host}:#{browser.process.port}#{path}"
+      end
 
       def default_domain
         if @started

--- a/lib/capybara/cuprite/driver.rb
+++ b/lib/capybara/cuprite/driver.rb
@@ -34,6 +34,8 @@ module Capybara
         @screen_size ||= DEFAULT_MAXIMIZE_SCREEN_SIZE
         @options[:save_path] ||= File.expand_path(Capybara.save_path) if Capybara.save_path
 
+        @options["remote-allow-origins"] = "*"
+
         ENV["FERRUM_DEBUG"] = "true" if ENV["CUPRITE_DEBUG"]
 
         super()

--- a/lib/capybara/cuprite/driver.rb
+++ b/lib/capybara/cuprite/driver.rb
@@ -34,7 +34,7 @@ module Capybara
         @screen_size ||= DEFAULT_MAXIMIZE_SCREEN_SIZE
         @options[:save_path] ||= File.expand_path(Capybara.save_path) if Capybara.save_path
 
-        @options["remote-allow-origins"] = "*"
+        @options[:"remote-allow-origins"] = "*"
 
         ENV["FERRUM_DEBUG"] = "true" if ENV["CUPRITE_DEBUG"]
 

--- a/spec/lib/driver_spec.rb
+++ b/spec/lib/driver_spec.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 describe Capybara::Cuprite::Driver do
+  describe "options" do
+    it "sets the remote-allow-origins option" do
+      driver = described_class.new nil
+
+      expect(driver.browser.options.to_h).to include("remote-allow-origins": "*")
+    end
+  end
+
   describe "save_path configuration" do
     it "defaults to the Capybara save path" do
       driver = with_capybara_save_path("/tmp/capybara-save-path") do

--- a/spec/lib/driver_spec.rb
+++ b/spec/lib/driver_spec.rb
@@ -21,6 +21,19 @@ describe Capybara::Cuprite::Driver do
     end
   end
 
+  describe "debug_url" do
+    it "parses the devtools frontend url correctly" do
+      driver = described_class.new nil, {port: 12345}
+      driver.browser # initialize browser before stubbing Net::HTTP as it also calls it
+      uri = instance_double URI
+
+      allow(driver).to receive(:URI).with("http://127.0.0.1:12345/json").and_return uri
+      allow(Net::HTTP).to receive(:get).with(uri).and_return "[{\"devtoolsFrontendUrl\":\"/works\"}]"
+
+      expect(driver.debug_url).to eq "http://127.0.0.1:12345/works"
+    end
+  end
+
   private
 
   def with_capybara_save_path(path)


### PR DESCRIPTION
The original debug url was deprecated apparently (I didn't confirm that; a call to `page.driver.debug` just opened a blank page).

Instead there is an endpoint now that allows to parse out a remote devtools frontend path (although they incorrectly call it a url).

So instead of generating a fixed debug_url now we make a request to said endpoint and parse the actual (dynamic; contains a uuid) devtools path and build a url from it.

For preliminary discussion see https://github.com/rubycdp/cuprite/issues/161