### PR TITLE
Docs: Update url allow/block instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ end
 `Cuprite`-specific options are:
 
 * options `Hash`
-  * `:url_blacklist` (Array) - array of strings to match against requested URLs
-  * `:url_whitelist` (Array) - array of strings to match against requested URLs
+  * `:url_blacklist` (Array) - array of regexes to match against requested URLs
+  * `:url_whitelist` (Array) - array of regexes to match against requested URLs
 
 
 ## Debugging


### PR DESCRIPTION
Currently, if you use a string to mark an allowed or blocked domain/url you get a noisy deprecation warning about the use of strings for these parameters. This change updates the instructions to specify the use of regexes instead which conforms to what Ferrum's code seems to expect (`pattern`) and silences the warning.