### PR TITLE
Update proxy documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Besides capybara screenshot method you can get image as Base64:
 
 ## Proxy
 
-* `page.driver.set_proxy(ip, port, type, user, password)`
+* `page.driver.set_proxy(ip, port, user, password)`
 
 
 ## URL Blacklisting & Whitelisting


### PR DESCRIPTION
Based to the code, the documentation about the proxy is wrong 
I corrected the documentation
See function : https://github.com/rubycdp/cuprite/blob/373b894d723bf9fb1afe31781963fe655a177218/lib/capybara/cuprite/driver.rb#L216-L218