### PR TITLE
Focus element when setting

### DIFF
--- a/lib/capybara/cuprite/javascripts/index.js
+++ b/lib/capybara/cuprite/javascripts/index.js
@@ -124,6 +124,7 @@ class Cuprite {
 
     let valueBefore = node.value;
 
+    node.focus();
     this.trigger(node, "focus");
     this.setValue(node, "");
 

--- a/spec/features/driver_spec.rb
+++ b/spec/features/driver_spec.rb
@@ -1534,6 +1534,19 @@ module Capybara
         end
       end
 
+      context "input_fields" do
+        before { @session.visit("/cuprite/input_fields") }
+
+        it "focuses the element when filling in the value" do
+          input = @session.find(:css, "#text_field")
+          @session.fill_in "text_field", with: "2016-02-14"
+
+          expect(@session.find(:css, "#text_field").value).to eq("2016-02-14")
+          node = @session.driver.evaluate_script("document.activeElement")
+          expect(node).to eq input
+        end
+      end
+
       context "evaluate_script" do
         it "can return an element" do
           @session.visit("/cuprite/send_keys")

--- a/spec/support/views/input_fields.erb
+++ b/spec/support/views/input_fields.erb
@@ -1,0 +1,9 @@
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+  <head>
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
+  </head>
+
+  <body>
+    <input type="text" id="text_field" name="text_field"/>
+  </body>
+</html>


### PR DESCRIPTION
The JS for filling in a field does not focus the element before filling it in, only triggers the focus event. This causes failures when checking the `document.activeElement` as the input will not be focused.

This fixes the issue by calling `focus` on the node before triggering the event.