### PR TITLE
Add support for `Node#obscured?`

### DIFF
--- a/lib/capybara/cuprite/browser.rb
+++ b/lib/capybara/cuprite/browser.rb
@@ -218,7 +218,7 @@ module Capybara
                 end
         return true if value == true
 
-        false
+        frame_obscured_at?(*value.values_at("x", "y"))
       end
 
       def all_text(node)
@@ -267,6 +267,21 @@ module Capybara
         target.maybe_sleep_if_new_window
         target.page = Page.new(target.client, context_id: target.context_id, target_id: target.id)
         target.page
+      end
+
+      def frame_obscured_at?(x, y)
+        frame = page.active_frame
+        return false if frame.main?
+
+        frame_node = frame.evaluate("window.frameElement")
+        return false unless frame_node
+
+        switch_to_frame(:parent)
+        begin
+          obscured?(frame_node, x, y)
+        ensure
+          switch_to_frame(frame)
+        end
       end
     end
   end

--- a/lib/capybara/cuprite/browser.rb
+++ b/lib/capybara/cuprite/browser.rb
@@ -210,6 +210,17 @@ module Capybara
         evaluate_on(node: node, expression: "_cuprite.path(this)")
       end
 
+      def obscured?(node, x = nil, y = nil)
+        value = if x && y
+                  evaluate_on(node: node, expression: "_cuprite.isObscured(this, #{x}, #{y})")
+                else
+                  evaluate_on(node: node, expression: "_cuprite.isObscured(this)")
+                end
+        return true if value == true
+
+        false
+      end
+
       def all_text(node)
         node.text
       end

--- a/lib/capybara/cuprite/browser.rb
+++ b/lib/capybara/cuprite/browser.rb
@@ -211,14 +211,11 @@ module Capybara
       end
 
       def obscured?(node, x = nil, y = nil)
-        value = if x && y
-                  evaluate_on(node: node, expression: "_cuprite.isObscured(this, #{x}, #{y})")
-                else
-                  evaluate_on(node: node, expression: "_cuprite.isObscured(this)")
-                end
-        return true if value == true
-
-        frame_obscured_at?(*value.values_at("x", "y"))
+        if x && y
+          evaluate_on(node: node, expression: "_cuprite.isObscured(this, #{x}, #{y})")
+        else
+          evaluate_on(node: node, expression: "_cuprite.isObscured(this)")
+        end
       end
 
       def all_text(node)
@@ -267,21 +264,6 @@ module Capybara
         target.maybe_sleep_if_new_window
         target.page = Page.new(target.client, context_id: target.context_id, target_id: target.id)
         target.page
-      end
-
-      def frame_obscured_at?(x, y)
-        frame = page.active_frame
-        return false if frame.main?
-
-        frame_node = frame.evaluate("window.frameElement")
-        return false unless frame_node
-
-        switch_to_frame(:parent)
-        begin
-          obscured?(frame_node, x, y)
-        ensure
-          switch_to_frame(frame)
-        end
       end
     end
   end

--- a/lib/capybara/cuprite/browser.rb
+++ b/lib/capybara/cuprite/browser.rb
@@ -210,12 +210,8 @@ module Capybara
         evaluate_on(node: node, expression: "_cuprite.path(this)")
       end
 
-      def obscured?(node, x = nil, y = nil)
-        if x && y
-          evaluate_on(node: node, expression: "_cuprite.isObscured(this, #{x}, #{y})")
-        else
-          evaluate_on(node: node, expression: "_cuprite.isObscured(this)")
-        end
+      def obscured?(node)
+        evaluate_on(node: node, expression: "_cuprite.isObscured(this)")
       end
 
       def all_text(node)

--- a/lib/capybara/cuprite/javascripts/index.js
+++ b/lib/capybara/cuprite/javascripts/index.js
@@ -119,18 +119,13 @@ class Cuprite {
    * Returns true if the node is obscured in the viewport.
    *
    * @param {Element} node
-   * @param {number} [x] the center position
-   * @param {number} [y] the center position
    * @return {boolean} true if the node is obscured, false otherwise
    */
-  isObscured(node, x, y) {
+  isObscured(node) {
     let win = window;
     let rect = node.getBoundingClientRect();
-    x = x ?? rect.width / 2;
-    y = y ?? rect.height / 2;
-
-    let px = rect.left + x;
-    let py = rect.top + y;
+    let px = rect.left + rect.width / 2;
+    let py = rect.top + rect.height / 2;
 
     while (win) {
       let topNode = win.document.elementFromPoint(px, py);

--- a/lib/capybara/cuprite/javascripts/index.js
+++ b/lib/capybara/cuprite/javascripts/index.js
@@ -115,6 +115,18 @@ class Cuprite {
     return `//${selectors.join("/")}`;
   }
 
+  isObscured(node, x, y) {
+    let rect = node.getBoundingClientRect();
+    if (x == null) x = rect.width/2;
+    if (y == null) y = rect.height/2;
+
+    let px = rect.left + x;
+    let py = rect.top + y;
+    let e = document.elementFromPoint(px, py);
+
+    return !node.contains(e) || { x: px, y: py };
+  }
+
   set(node, value) {
     if (node.readOnly) return;
 

--- a/lib/capybara/cuprite/javascripts/index.js
+++ b/lib/capybara/cuprite/javascripts/index.js
@@ -115,16 +115,38 @@ class Cuprite {
     return `//${selectors.join("/")}`;
   }
 
+  /**
+   * Returns true if the node is obscured in the viewport.
+   *
+   * @param {Element} node
+   * @param {number} [x] the center position
+   * @param {number} [y] the center position
+   * @return {boolean} true if the node is obscured, false otherwise
+   */
   isObscured(node, x, y) {
+    let win = window;
     let rect = node.getBoundingClientRect();
-    if (x == null) x = rect.width/2;
-    if (y == null) y = rect.height/2;
+    x = x ?? rect.width / 2;
+    y = y ?? rect.height / 2;
 
     let px = rect.left + x;
     let py = rect.top + y;
-    let e = document.elementFromPoint(px, py);
 
-    return !node.contains(e) || { x: px, y: py };
+    while (win) {
+      let topNode = win.document.elementFromPoint(px, py);
+
+      if (node !== topNode && !node.contains(topNode)) return true;
+
+      node = win.frameElement;
+      if (!node) return false;
+
+      rect = node.getBoundingClientRect();
+      px = rect.left + px;
+      py = rect.top + py;
+      win = win.parent;
+    }
+
+    return false;
   }
 
   set(node, value) {

--- a/lib/capybara/cuprite/node.rb
+++ b/lib/capybara/cuprite/node.rb
@@ -213,6 +213,10 @@ module Capybara
         command(:path)
       end
 
+      def obscured?(x: nil, y: nil)
+        command(:obscured?, x, y)
+      end
+
       def inspect
         %(#<#{self.class} @node=#{@node.inspect}>)
       end

--- a/lib/capybara/cuprite/node.rb
+++ b/lib/capybara/cuprite/node.rb
@@ -213,8 +213,8 @@ module Capybara
         command(:path)
       end
 
-      def obscured?(x: nil, y: nil)
-        command(:obscured?, x, y)
+      def obscured?
+        command(:obscured?)
       end
 
       def inspect

--- a/lib/capybara/cuprite/page.rb
+++ b/lib/capybara/cuprite/page.rb
@@ -138,14 +138,6 @@ module Capybara
         false
       end
 
-      def active_frame
-        if @frame_stack.empty?
-          main_frame
-        else
-          @frames[@frame_stack.last]
-        end
-      end
-
       private
 
       def prepare_page
@@ -187,6 +179,14 @@ module Capybara
         raise MouseEventFailed, "MouseEventFailed: click, none, 0, 0" if e.message == "Could not compute content quads."
 
         raise
+      end
+
+      def active_frame
+        if @frame_stack.empty?
+          main_frame
+        else
+          @frames[@frame_stack.last]
+        end
       end
     end
   end

--- a/lib/capybara/cuprite/page.rb
+++ b/lib/capybara/cuprite/page.rb
@@ -138,6 +138,14 @@ module Capybara
         false
       end
 
+      def active_frame
+        if @frame_stack.empty?
+          main_frame
+        else
+          @frames[@frame_stack.last]
+        end
+      end
+
       private
 
       def prepare_page
@@ -179,14 +187,6 @@ module Capybara
         raise MouseEventFailed, "MouseEventFailed: click, none, 0, 0" if e.message == "Could not compute content quads."
 
         raise
-      end
-
-      def active_frame
-        if @frame_stack.empty?
-          main_frame
-        else
-          @frames[@frame_stack.last]
-        end
       end
     end
   end

--- a/spec/features/session_spec.rb
+++ b/spec/features/session_spec.rb
@@ -314,6 +314,31 @@ describe Capybara::Session do
       end
     end
 
+    describe "Node#obscured?" do
+      context "when the element is not in the viewport of parent element" do
+        before do
+          @session.visit("/cuprite/scroll")
+        end
+
+        it "is is a boolean" do
+          expect(@session.find_link("Link outside viewport").obscured?).to be true
+          expect(@session.find_link("Below the fold").obscured?).to be true
+        end
+      end
+
+      context "when the element is only overlapped by descendants" do
+        before do
+          @session.visit("/with_html")
+        end
+
+        # copied from https://github.com/teamcapybara/capybara/blob/master/lib/capybara/spec/session/node_spec.rb#L328
+        # as this example is currently disabled on CI in the upstream suite
+        it "is not obscured" do
+          expect(@session.first(:css, "p:not(.para)")).not_to be_obscured
+        end
+      end
+    end
+
     it "has no trouble clicking elements when the size of a document changes" do
       @session.visit("/cuprite/long_page")
       @session.find(:css, "#penultimate").click

--- a/spec/features/session_spec.rb
+++ b/spec/features/session_spec.rb
@@ -321,8 +321,8 @@ describe Capybara::Session do
         end
 
         it "is is a boolean" do
-          expect(@session.find_link("Link outside viewport").obscured?).to be true
-          expect(@session.find_link("Below the fold").obscured?).to be true
+          expect(@session.find_link("Link outside viewport")).to be_obscured
+          expect(@session.find_link("Below the fold")).to be_obscured
         end
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,7 +37,6 @@ end
 RSpec.configure do |config|
   config.define_derived_metadata do |metadata|
     regexes = <<~REGEXP.split("\n").map { |s| Regexp.quote(s.strip) }.join("|")
-      node #obscured? should work in nested iframes
       node #drag_to should work with jsTree
       node #drag_to should drag and drop an object
       node #drag_to should drag and drop if scrolling is needed

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,7 +37,7 @@ end
 RSpec.configure do |config|
   config.define_derived_metadata do |metadata|
     regexes = <<~REGEXP.split("\n").map { |s| Regexp.quote(s.strip) }.join("|")
-      node #obscured?
+      node #obscured? should work in nested iframes
       node #drag_to should work with jsTree
       node #drag_to should drag and drop an object
       node #drag_to should drag and drop if scrolling is needed
@@ -68,10 +68,6 @@ RSpec.configure do |config|
       node #path reports when element in shadow dom
       node #shadow_root
       node #set should submit single text input forms if ended with
-      #all with obscured filter should only find nodes on top in the viewport when false
-      #all with obscured filter should not find nodes on top outside the viewport when false
-      #all with obscured filter should find top nodes outside the viewport when true
-      #all with obscured filter should only find non-top nodes when true
       #fill_in should fill in a color field
       #fill_in should handle carriage returns with line feeds in a textarea correctly
       #has_field with valid should be false if field is invalid


### PR DESCRIPTION
This PR adds initial support for `Node#obscured?`.

Enables the `obscured:` option with `Capybara::Node::Finders#all`, `Capybara::Node::Finders#find` and the various assertion methods and matchers that support the same options, e.g.

```ruby
      assert_selector("button[data-close-dialog-id]", obscured: false)
      assert_selector("button[data-submit-dialog-id]", obscured: false)
```

Essentially it is a port of `Capybara::Selenium::Node#obscured?` including the injected script ([`Capybara::Selenium::Node::OBSCURED_OR_OFFSET_SCRIPT`](https://github.com/teamcapybara/capybara/blob/master/lib/capybara/selenium/node.rb#L545)).

A couple things to note:
- This PR also includes #201 - albeit [with one small fix](https://github.com/rubycdp/cuprite/pull/201#discussion_r1960733791). Without it I'm seeing a `undefined method `execution_id!' for nil` error (details below).
- I struggled with the fact that a `Ferrum::Frame` is not a `Ferrum::Node` - in the Selenium implementation, frames are `Capybara::Node::Element`. ~~The code that gets the corresponding `iframe` `Node` for a given frame is hacky - ideally `Ferrum::Frame` would provided a `#to_node` node or similar.~~ 
- There is now an upstream PR implementing `Ferrum::Frame#node`: https://github.com/rubycdp/ferrum/pull/524 - This PR isn't dependent on the upstream PR being merged, but it could easily be adapted.

---

<details><summary><code>undefined method `execution_id!' for nil</code> stack trace</summary>
<code><pre>
  1) Capybara::Session Cuprite node #obscured? should work in nested iframes
     Failure/Error: inject_extensions
     
     NoMethodError:
       undefined method `execution_id!' for nil
     # /Users/alexbcoles/.gem/ruby/3.3.4/gems/ferrum-0.16/lib/ferrum/page.rb:490:in `block in inject_extensions'
     # /Users/alexbcoles/.gem/ruby/3.3.4/gems/ferrum-0.16/lib/ferrum/page.rb:483:in `each'
     # /Users/alexbcoles/.gem/ruby/3.3.4/gems/ferrum-0.16/lib/ferrum/page.rb:483:in `inject_extensions'
     # ./lib/capybara/cuprite/page.rb:126:in `switch_to_frame'
     # ./lib/capybara/cuprite/browser.rb:284:in `frame_obscured_at?'
     # ./lib/capybara/cuprite/browser.rb:221:in `obscured?'
     # ./lib/capybara/cuprite/node.rb:21:in `command'
     # ./lib/capybara/cuprite/node.rb:217:in `obscured?'
     # /Users/alexbcoles/.gem/ruby/3.3.4/gems/capybara-3.40.0/lib/capybara/node/element.rb:317:in `block in obscured?'
     # /Users/alexbcoles/.gem/ruby/3.3.4/gems/capybara-3.40.0/lib/capybara/node/base.rb:84:in `synchronize'
     # /Users/alexbcoles/.gem/ruby/3.3.4/gems/capybara-3.40.0/lib/capybara/node/element.rb:317:in `obscured?'
     # /Users/alexbcoles/.gem/ruby/3.3.4/gems/capybara-3.40.0/lib/capybara/spec/session/node_spec.rb:358:in `block (6 levels) in <top (required)>'
     # /Users/alexbcoles/.gem/ruby/3.3.4/gems/capybara-3.40.0/lib/capybara/session.rb:451:in `within_frame'
     # /Users/alexbcoles/.gem/ruby/3.3.4/gems/capybara-3.40.0/lib/capybara/spec/session/node_spec.rb:357:in `block (5 levels) in <top (required)>'
     # /Users/alexbcoles/.gem/ruby/3.3.4/gems/capybara-3.40.0/lib/capybara/session.rb:451:in `within_frame'
     # /Users/alexbcoles/.gem/ruby/3.3.4/gems/capybara-3.40.0/lib/capybara/spec/session/node_spec.rb:355:in `block (4 levels) in <top (required)>'
     # /Users/alexbcoles/.gem/ruby/3.3.4/gems/capybara-3.40.0/lib/capybara/session.rb:451:in `within_frame'
     # /Users/alexbcoles/.gem/ruby/3.3.4/gems/capybara-3.40.0/lib/capybara/spec/session/node_spec.rb:354:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:109:in `block (2 levels) in <top (required)>'
</pre></code>
</details> 