### PR TITLE
Enable mobile emulation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "byebug", "~> 11.1", platforms: %i[mri windows]
 gem "chunky_png", "~> 1.4"
+gem "ferrum", github: "radiopaedia/ferrum", branch: "94-expose-mobile"
 gem "image_size", "~> 3.0"
 gem "launchy", "~> 2.5"
 gem "logger"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Capybara.register_driver(:cuprite) do |app|
 end
 ```
 
-if you use `Docker` don't forget to pass `no-sandbox` option:
+If you use `Docker` don't forget to pass `no-sandbox` option:
 
 ```ruby
 Capybara::Cuprite::Driver.new(app, browser_options: { 'no-sandbox': nil })

--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ end
   * `:url_blacklist` (Array) - array of regexes to match against requested URLs
   * `:url_whitelist` (Array) - array of regexes to match against requested URLs
 
+You can emulate specific devices at the time you register a driver:
+
+```ruby
+require "capybara/cuprite/devices"
+Capybara.register_driver(:cuprite) do |app|
+  Capybara::Cuprite::Driver.new(app, Capybara::Cuprite::Devices::IPHONE_14)
+end
+```
 
 ## Debugging
 

--- a/lib/capybara/cuprite/devices.rb
+++ b/lib/capybara/cuprite/devices.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Capybara
+  module Cuprite
+    module Devices
+      IPHONE_14 = { window_size: [390, 844], mobile: true, scale_factor: 3 }
+    end
+  end
+end

--- a/lib/capybara/cuprite/devices.rb
+++ b/lib/capybara/cuprite/devices.rb
@@ -3,7 +3,9 @@
 module Capybara
   module Cuprite
     module Devices
-      IPHONE_14 = { window_size: [390, 844], mobile: true, scale_factor: 3 }
+      # It's idiomatic to merge other options into these, so freezing
+      # isn't the right thing to do.
+      IPHONE_14 = { window_size: [390, 844], mobile: true, scale_factor: 3 } # rubocop:disable Style/MutableConstant
     end
   end
 end

--- a/lib/capybara/cuprite/page.rb
+++ b/lib/capybara/cuprite/page.rb
@@ -145,7 +145,11 @@ module Capybara
         super
 
         width, height = @options.window_size
-        resize(width: width, height: height, mobile: @options.mobile)
+        if @options.mobile
+          resize(width: 0, height: 0, mobile: @options.mobile)
+        else
+          resize(width: width, height: height, mobile: @options.mobile)
+        end
 
         if @options.url_blacklist.any?
           network.blacklist = @options.url_blacklist

--- a/lib/capybara/cuprite/page.rb
+++ b/lib/capybara/cuprite/page.rb
@@ -145,7 +145,7 @@ module Capybara
         super
 
         width, height = @options.window_size
-        resize(width: width, height: height)
+        resize(width: width, height: height, mobile: @options.mobile)
 
         if @options.url_blacklist.any?
           network.blacklist = @options.url_blacklist

--- a/lib/capybara/cuprite/page.rb
+++ b/lib/capybara/cuprite/page.rb
@@ -145,11 +145,7 @@ module Capybara
         super
 
         width, height = @options.window_size
-        if @options.mobile
-          resize(width: 0, height: 0, mobile: @options.mobile)
-        else
-          resize(width: width, height: height, mobile: @options.mobile)
-        end
+        resize(width: width, height: height, mobile: @options.mobile)
 
         if @options.url_blacklist.any?
           network.blacklist = @options.url_blacklist

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ require "shellwords"
 
 require "capybara/spec/spec_helper"
 require "capybara/cuprite"
+require "capybara/cuprite/devices"
 
 require "support/test_app"
 require "support/external_browser"
@@ -30,7 +31,7 @@ Capybara.register_driver(:cuprite) do |app|
 end
 
 Capybara.register_driver(:cuprite_mobile) do |app|
-  options = { mobile: true }
+  options = Capybara::Cuprite::Devices::IPHONE_14
   options.merge!(inspector: true) if ENV["INSPECTOR"]
   options.merge!(logger: StringIO.new) if ENV["CI"]
   options.merge!(headless: false) if ENV["HEADLESS"] == "false"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,6 +39,7 @@ end
 
 module TestSessions
   Cuprite = Capybara::Session.new(:cuprite, TestApp)
+  CupriteMobile = Capybara::Session.new(:cuprite_mobile, TestApp)
 end
 
 RSpec.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,14 @@ Capybara.register_driver(:cuprite) do |app|
   Capybara::Cuprite::Driver.new(app, options)
 end
 
+Capybara.register_driver(:cuprite_mobile) do |app|
+  options = { mobile: true }
+  options.merge!(inspector: true) if ENV["INSPECTOR"]
+  options.merge!(logger: StringIO.new) if ENV["CI"]
+  options.merge!(headless: false) if ENV["HEADLESS"] == "false"
+  Capybara::Cuprite::Driver.new(app, options)
+end
+
 module TestSessions
   Cuprite = Capybara::Session.new(:cuprite, TestApp)
 end

--- a/spec/support/views/mobile.erb
+++ b/spec/support/views/mobile.erb
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Mobile test page</title>
+    <style>
+      @media (min-width: 1000px) {
+        .desktop { display: block; }
+        .mobile { display: none; }
+      }
+
+      @media (max-width: 999px) {
+        .desktop { display: none; }
+        .mobile { display: block; }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="desktop">
+      I am a desktop.
+    </div>
+
+    <div class="mobile">
+      I am a mobile.
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
:rotating_light: Needs https://github.com/rubycdp/ferrum/pull/527 before merging. :rotating_light: 

Currently, when creating a Cuprite driver, it's not possible to specify that it should have mobile emulation enabled.

This PR adds that functionality.

Remember to revert 5117a90e628f9632ef0f65eadea457a4f4c4a79a once https://github.com/rubycdp/ferrum/pull/527 is merged.

