### PR TITLE
Extend Node#set with additional input types

### DIFF
--- a/lib/capybara/cuprite/node.rb
+++ b/lib/capybara/cuprite/node.rb
@@ -89,7 +89,7 @@ module Capybara
         command(:value)
       end
 
-      def set(value, options = {}) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      def set(value, options = {}) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize
         warn "Options passed to Node#set but Cuprite doesn't currently support any - ignoring" unless options.empty?
 
         if tag_name == "input"

--- a/lib/capybara/cuprite/node.rb
+++ b/lib/capybara/cuprite/node.rb
@@ -131,23 +131,6 @@ module Capybara
         end
       end
 
-      # Copied from MIT licensed capybara project
-      # revision 0be79d6
-      # path lib/capybara/selenium/node.rb
-      def set_value_js(value)
-        driver.execute_script(<<-JS, self, value)
-          if (arguments[0].readOnly) { return };
-          if (document.activeElement !== arguments[0]){
-            arguments[0].focus();
-          }
-          if (arguments[0].value != arguments[1]) {
-            arguments[0].value = arguments[1]
-            arguments[0].dispatchEvent(new InputEvent('input'));
-            arguments[0].dispatchEvent(new Event('change', { bubbles: true }));
-          }
-        JS
-      end
-
       def select_option
         command(:select, true)
       end

--- a/lib/capybara/cuprite/node.rb
+++ b/lib/capybara/cuprite/node.rb
@@ -116,9 +116,7 @@ module Capybara
             value = value.to_date.strftime("%G-W%V") if !value.is_a?(String) && value.respond_to?(:to_date)
             command(:set, value.to_s)
           when "datetime-local"
-            value = value.to_time.strftime('%Y-%m-%dT%H:%M') if !value.is_a?(String) && value.respond_to?(:to_time)
-            command(:set, value.to_s)
-          when "range"
+            value = value.to_time.strftime("%Y-%m-%dT%H:%M") if !value.is_a?(String) && value.respond_to?(:to_time)
             command(:set, value.to_s)
           else
             command(:set, value.to_s)

--- a/spec/features/driver_spec.rb
+++ b/spec/features/driver_spec.rb
@@ -1468,6 +1468,30 @@ module Capybara
           expect(input.text).to eq("replacement text")
         end
 
+        it "sets a date field" do
+          input = @session.find(:css, "#date-field")
+          input.set(Time.new(2000, 12, 31))
+          expect(input.value).to eq("2000-12-31")
+        end
+
+        it "sets a datetime-local field" do
+          input = @session.find(:css, "#datetime-local-field")
+          input.set(Time.new(2000, 12, 31, 17, 15))
+          expect(input.value).to eq(Time.new(2000, 12, 31, 17, 15).strftime("%Y-%m-%dT%H:%M"))
+        end
+
+        it "sets a range field" do
+          input = @session.find(:css, "#range-field")
+          input.set(42)
+          expect(input.value).to eq("42")
+        end
+
+        it "sets a color field" do
+          input = @session.find(:css, "#color-field")
+          input.set("#1270a4")
+          expect(input.value).to eq("#1270a4")
+        end
+
         it "sets a content editable childs content" do
           @session.visit("/with_js")
           @session.find(:css, "#existing_content_editable_child").set("WYSIWYG")

--- a/spec/support/views/set.erb
+++ b/spec/support/views/set.erb
@@ -1,6 +1,8 @@
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
   <head>
-    <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8">
+    <title>Set tests</title>
   </head>
 
   <body>

--- a/spec/support/views/set.erb
+++ b/spec/support/views/set.erb
@@ -8,5 +8,11 @@
   <body>
     <div id="empty_div" contenteditable="true"></div>
     <div id="filled_div" contenteditable="true">Content</div>
+    <form>
+      <input id="date-field" type="date" name="date-field"><br>
+      <input id="datetime-local-field" type="datetime-local" name="datetime-local-field"><br>
+      <input id="range-field" type="range" min="0" max="100" name="range-field"><br>
+      <input id="color-field" type="color" name="color-field">
+    </form>
   </body>
 </html>


### PR DESCRIPTION
This PR introduces a new targets to `Page#set`:

* datetime-local

... and adds some tests for existing targets.