### PR TITLE
Focus form control elements during `fill_in`

### DIFF
--- a/lib/capybara/cuprite/javascripts/index.js
+++ b/lib/capybara/cuprite/javascripts/index.js
@@ -153,7 +153,7 @@ class Cuprite {
 
     let valueBefore = node.value;
 
-    this.trigger(node, "focus");
+    node.focus();
     this.setValue(node, "");
 
     if (node.type == "number" || node.type == "date" || node.type == "range") {

--- a/spec/features/driver_spec.rb
+++ b/spec/features/driver_spec.rb
@@ -1533,7 +1533,7 @@ module Capybara
         it "fills a date" do
           @session.fill_in "date_field", with: "2016-02-14"
 
-          expect(@session.find(:css, "#date_field").value).to eq("2016-02-14")
+          expect(@session.find(:css, "#date_field", focused: true).value).to eq("2016-02-14")
         end
       end
 


### PR DESCRIPTION
Closes https://github.com/rubycdp/cuprite/issues/157
Related to https://github.com/rubycdp/cuprite/pull/280

Change the `lib/capybara/cuprite/javascripts/index.js` to invoke [HTMLElement.focus][] directly, rather than triggering a synthetic `"focus"` event.

[HTMLElement.focus]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus