### PR TITLE
Allow time inputs to be filled with time strings

### DIFF
--- a/lib/capybara/cuprite/node.rb
+++ b/lib/capybara/cuprite/node.rb
@@ -103,6 +103,8 @@ module Capybara
             command(:select_file, files)
           when "color"
             node.evaluate("this.setAttribute('value', '#{value}')")
+          when "time"
+            command(:set, value.is_a?(String) ? Time.parse(value).to_s : value.to_s)
           else
             command(:set, value.to_s)
           end

--- a/spec/features/driver_spec.rb
+++ b/spec/features/driver_spec.rb
@@ -1537,6 +1537,34 @@ module Capybara
         end
       end
 
+      context "time_fields" do
+        before { @session.visit("/cuprite/time_fields") }
+
+        it "sets a time with HH:MM format" do
+          input = @session.find(:css, "#time_field")
+          input.set("10:00")
+          expect(input.value).to eq("10:00:00")
+        end
+
+        it "sets a time with HH:MM:SS format" do
+          input = @session.find(:css, "#time_field")
+          input.set("14:30:45")
+          expect(input.value).to eq("14:30:45")
+        end
+
+        it "sets a time from a Time object" do
+          input = @session.find(:css, "#time_field")
+          time = Time.parse("10:30:00")
+          input.set(time)
+          expect(input.value).to match(/10:30:0?0/)
+        end
+
+        it "fills in a time field with a time string" do
+          @session.fill_in "time_field", with: "09:15"
+          expect(@session.find(:css, "#time_field").value).to eq("09:15:00")
+        end
+      end
+
       context "evaluate_script" do
         it "can return an element" do
           @session.visit("/cuprite/send_keys")

--- a/spec/support/views/time_fields.erb
+++ b/spec/support/views/time_fields.erb
@@ -1,0 +1,9 @@
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+  <head>
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
+  </head>
+
+  <body>
+    <input type="time" id="time_field" name="time_field"/>
+  </body>
+</html>


### PR DESCRIPTION
Allows us to use time strings like `10:00` as values for a `time` input.

I've spent a lot of time thinking I had a bug because a simple `fill_in "time_field", with: "10:00"` didn't work. It seems to expect a time object only but that's not mentioned anywhere AFAIK.

This adds the ability to set times as strings which would work normally in JS `element.value = "10:00"`