### PR TITLE
Implement `Capybara::Cuprite::Node#rect`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 - Support time inputs [#245]
 - Add initial support for shadow_root [#234]
+- Support `Capybara::Cuprite::Node#rect` [#276]
 
 ### Changed
 

--- a/lib/capybara/cuprite/node.rb
+++ b/lib/capybara/cuprite/node.rb
@@ -236,6 +236,12 @@ module Capybara
         root && self.class.new(driver, root.node)
       end
 
+      def rect
+        driver.evaluate_script <<~JS, self
+          arguments[0].getBoundingClientRect().toJSON()
+        JS
+      end
+
       def inspect
         %(#<#{self.class} @node=#{@node.inspect}>)
       end

--- a/spec/features/driver_spec.rb
+++ b/spec/features/driver_spec.rb
@@ -1447,6 +1447,20 @@ module Capybara
         end
       end
 
+      context "find" do
+        before { @session.visit("/cuprite/click_coordinates") }
+
+        it "supports position filters" do
+          box = @session.find(:css, "#box")
+          log = @session.find(:css, "#log")
+
+          expect(@session).to have_element(id: "box", above: log)
+          expect(@session).to have_element(id: "log", below: box)
+          expect(@session).not_to have_element(id: "box", below: log)
+          expect(@session).not_to have_element(id: "log", above: box)
+        end
+      end
+
       context "set" do
         before { @session.visit("/cuprite/set") }
 


### PR DESCRIPTION
Closes https://github.com/rubycdp/cuprite/issues/276

The implementation's call to [toJSON][] is necessary since the object returned by [Element.getBoundingClientRect][] is an instance of [DOMRect][], and is therefore unable to have its keys iterated and serialized back to Cuprite on its own.

[Element.getBoundingClientRect]: https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect
[DOMRect]: https://developer.mozilla.org/en-US/docs/Web/API/DOMRect
[toJSON]: https://github.com/segment-boneyard/nightmare/issues/723#issuecomment-374683727