### PR TITLE
Fix driver node frame switching

### DIFF
--- a/lib/capybara/cuprite/driver.rb
+++ b/lib/capybara/cuprite/driver.rb
@@ -110,9 +110,13 @@ module Capybara
         handle = case locator
                  when Capybara::Node::Element
                    locator.native.description["frameId"]
+                 when Capybara::Cuprite::Node
+                   locator.description["frameId"]
                  when :parent, :top
                    locator
                  end
+
+        raise ArgumentError, "Unable to switch to frame from #{locator.class}" unless handle
 
         browser.switch_to_frame(handle)
       end

--- a/spec/features/session_spec.rb
+++ b/spec/features/session_spec.rb
@@ -813,6 +813,27 @@ describe Capybara::Session do
         end
       end
 
+      it "supports selection by driver node" do
+        @session.visit "/cuprite/frames"
+        frame = @session.driver.find_css("iframe[name]").first
+
+        @session.driver.switch_to_frame(frame)
+        expect(@session.driver.frame_url).to end_with("/cuprite/slow")
+      ensure
+        @session.driver.switch_to_frame(:top)
+      end
+
+      it "rejects driver nodes without frame ids" do
+        @session.visit "/cuprite/simple"
+        node = @session.driver.find_css("body").first
+
+        expect do
+          @session.driver.switch_to_frame(node)
+        end.to raise_error(ArgumentError, /Unable to switch to frame/)
+
+        expect(@session.driver.frame_url).to end_with("/cuprite/simple")
+      end
+
       it "supports selection by element without name or id" do
         @session.visit "/cuprite/frames"
         frame = @session.find(:css, "iframe:not([name]):not([id])")


### PR DESCRIPTION
## Summary

- Allow `Driver#switch_to_frame` to accept `Capybara::Cuprite::Node`
- Add regression coverage for switching frames with a driver node

## Root Cause

Driver-level frame traversal can pass a `Capybara::Cuprite::Node`, but `switch_to_frame` only extracted `frameId` from wrapped `Capybara::Node::Element` instances. Direct driver nodes therefore pushed a `nil` frame handle and left the frame stack invalid.

## Impact

Libraries that work below Capybara session DSL can now switch into iframe nodes returned by Cuprite driver APIs without losing context.

This change is needed to fully support Cuprite/Ferrum in another library: https://github.com/dequelabs/axe-core-gems/pull/509

## Validation

- `bundle exec rspec spec/features/session_spec.rb -e "frame support"`
- `bundle exec rspec spec/features/driver_spec.rb:1637`
- `git diff --check HEAD~1..HEAD`
