### PR TITLE
fix: ignore empty or nil keys in `Node#send_keys`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 - Ensure node has focus before setting value [#280]
+- `Capybara::Cuprite::Node#send_keys` ignores empty or nil keys instead of raising, matching the Selenium and rack_test drivers
 
 ### Removed
 

--- a/lib/capybara/cuprite/node.rb
+++ b/lib/capybara/cuprite/node.rb
@@ -220,6 +220,9 @@ module Capybara
       end
 
       def send_keys(*keys)
+        keys = keys.reject { |key| key.nil? || key == "" }
+        return if keys.empty?
+
         command(:send_keys, keys)
       end
       alias send_key send_keys

--- a/spec/features/driver_spec.rb
+++ b/spec/features/driver_spec.rb
@@ -1272,6 +1272,15 @@ module Capybara
           expect(input.value).to eq("Text appended")
         end
 
+        it "ignores empty or nil keys instead of raising" do
+          input = @session.find(:css, "#filled_input")
+
+          expect { input.native.send_keys("") }.not_to raise_error
+          expect { input.native.send_keys(nil) }.not_to raise_error
+
+          expect(input.value).to eq("Text")
+        end
+
         it "sends keys to empty textarea" do
           input = @session.find(:css, "#empty_textarea")
 


### PR DESCRIPTION
## Problem

`Capybara::Cuprite::Node#send_keys` raises on empty or nil keys, diverging from the Selenium and rack_test drivers which treat them as a no-op:

```ruby
input.send_keys("")   # => ArgumentError: empty keys passed
input.send_keys(nil)  # => ArgumentError: unexpected argument
```

`send_keys` forwards straight to `Ferrum::Keyboard#type`, which rejects empty/nil input. This breaks otherwise driver-agnostic Capybara code such as `send_keys(value)` where `value` may be `""` — common when conditionally clearing or filling a field. Callers currently have to add their own `send_keys(x) if x` guards for Cuprite only.

Real world example: https://github.com/citizensadvice/capybara_accessible_selectors/pull/157/changes#diff-8a7441fcb90a95d9647b64ef89630240641dfb8cd8d88ea3d4768d4053e8af5aR75

## Fix

Reject `nil` and `""` entries before delegating to Ferrum, and no-op when nothing remains. Meaningful keys (including symbols like `:enter` and modifier chords like `[:control, "a"]`) pass through unchanged, and empty strings mixed with real keys are dropped rather than crashing.

## Testing

New spec in the "has ability to send keys" context asserts `send_keys("")` and `send_keys(nil)` do not raise and leave the field unchanged. Full send_keys context green (25 examples). Rubocop clean.
