### PR TITLE
Treat closed <details> non-summary descendants as non-visible

### DIFF
--- a/lib/capybara/cuprite/javascripts/index.js
+++ b/lib/capybara/cuprite/javascripts/index.js
@@ -85,7 +85,16 @@ class Cuprite {
         if (style.display === "none" || style.visibility === "hidden" || parseFloat(style.opacity) === 0) {
           return false;
         }
-        node = node.parentElement ?? (node.getRootNode() instanceof ShadowRoot && node.getRootNode());
+
+        let parent = node.parentElement;
+        if (parent && parent.tagName === "DETAILS" && !parent.open) {
+          // In a closed <details> only the first <summary> (and its subtree) is rendered.
+          if (node !== parent.querySelector(":scope > summary")) {
+            return false;
+          }
+        }
+
+        node = parent ?? (node.getRootNode() instanceof ShadowRoot && node.getRootNode());
       }
     }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -56,8 +56,6 @@ RSpec.configure do |config|
       node Element#drop can drop strings
       node Element#drop can drop multiple strings
       node Element#drop can drop a pathname
-      node #visible? details non-summary descendants should be non-visible
-      node #visible? works when details is toggled open and closed
       node #set should submit single text input forms if ended with
       node #shadow_root should produce error messages when failing
       #has_field with valid should be false if field is invalid


### PR DESCRIPTION
## What

Treats non-summary descendants of a **closed** `<details>` element as non-visible, un-skipping 2 Capybara `#visible?` shared specs.

## Why

`_cuprite.isVisible` walked the ancestor chain checking only `display:none` / `visibility:hidden` / `opacity:0`. A closed `<details>` hides its non-summary children via the rendering model, not computed `display` — so `getComputedStyle(child).display` is `block` and those children were reported visible.

## How

In the `isVisible` ancestor walk: if a node's parent is a `<details>` without `[open]` and the node is not that details' first `<summary>`, return `false`.

- Deep descendants are caught as the walk ascends to the direct child of the `<details>`.
- The first `<summary>` (and its subtree) stays visible; a second `<summary>` is correctly hidden.
- Open details are unaffected (`!parent.open` short-circuits); toggling reads the live `.open` state.

## Testing

- The 2 previously-skipped specs now pass (`details non-summary descendants should be non-visible when closed`, `works when details is toggled open and closed`), alongside the already-passing closed-summary-visible and open-details-visible specs.
- Regression: 58 `#visible?` / visibility examples, 0 failures.
- `bundle exec rubocop` clean.

Part of #307.

<sub>🤖 Authored with agent assistance.</sub>
