### PR TITLE
Report tag_name as ShadowRoot for shadow roots

### DIFF
--- a/lib/capybara/cuprite/node.rb
+++ b/lib/capybara/cuprite/node.rb
@@ -139,7 +139,7 @@ module Capybara
       end
 
       def tag_name
-        @tag_name ||= description["nodeName"].downcase
+        @tag_name ||= description["shadowRootType"] ? "ShadowRoot" : description["nodeName"].downcase
       end
 
       def visible?

--- a/spec/features/session_spec.rb
+++ b/spec/features/session_spec.rb
@@ -452,7 +452,7 @@ describe Capybara::Session do
         shadow_root = @session.find(:css, "#shadow_host").shadow_root
         expect do
           expect(shadow_root).to have_css("#shadow_content", text: "Not in the document")
-        end.to raise_error(/tag="#document-fragment"/)
+        end.to raise_error(/tag="ShadowRoot"/)
       end
 
       it "extends visibility check across shadow host boundary" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,7 +59,6 @@ RSpec.configure do |config|
       node #visible? details non-summary descendants should be non-visible
       node #visible? works when details is toggled open and closed
       node #set should submit single text input forms if ended with
-      node #shadow_root should produce error messages when failing
       #has_field with valid should be false if field is invalid
       #has_element? should be true if the given element is on the page
       #assert_matches_style should raise error if the elements style doesn't contain the given properties


### PR DESCRIPTION
## What

Reports `tag_name` as `"ShadowRoot"` for shadow-root nodes, un-skipping the Capybara `#shadow_root should produce error messages when failing` shared spec.

## Why

`Node#tag_name` derived from `description["nodeName"]`, which for a shadow root is `#document-fragment`. So failure messages scoped to a shadow root read `tag="#document-fragment"`, whereas Capybara (and Selenium) expect `tag="ShadowRoot"`.

## How

`tag_name` now returns `"ShadowRoot"` when the node's CDP description carries `shadowRootType` (present only on shadow roots); everything else is unchanged. Other `tag_name` comparisons in the driver are against lowercased HTML tags, which a shadow root never matched anyway.

The repo's own `Node#shadow_root` spec previously asserted the old `tag="#document-fragment"` output; it's updated to the corrected `tag="ShadowRoot"`.

## Testing

- The previously-skipped shared spec now passes.
- All shadow-DOM specs green (11 examples: shared + Cuprite's own), plus a node regression pass (`#tag_name`, `#[]`, `#value`, `#path`).
- `bundle exec rubocop` clean.

Part of #307.

<sub>🤖 Authored with agent assistance.</sub>
